### PR TITLE
Add arena barriers

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 use bevy::prelude::*;
 use bevy_rapier2d::{na::Vector2, prelude::*};
 
+mod misc;
 mod player;
 
 fn main() {
@@ -14,8 +15,9 @@ fn main() {
         .add_plugins(DefaultPlugins)
         .add_plugin(RapierPhysicsPlugin::<NoUserData>::default())
         //.add_plugin(RapierRenderPlugin)
-        .add_startup_system(setup_game.system())
-        .add_startup_system(player::spawn_player_system.system())
+        .add_startup_system(setup_game.system().label("init"))
+        .add_startup_system(misc::spawn_barrier_system.system().after("init"))
+        .add_startup_system(player::spawn_player_system.system().after("init"))
         .add_system(player::player_movement_system.system())
         .add_system(print_player_position.system())
         .run();

--- a/src/misc/mod.rs
+++ b/src/misc/mod.rs
@@ -1,0 +1,5 @@
+//! `thetawave_lib` misc module
+
+mod spawn;
+
+pub use self::spawn::spawn_barrier_system;

--- a/src/misc/spawn.rs
+++ b/src/misc/spawn.rs
@@ -3,72 +3,23 @@ use bevy_rapier2d::prelude::*;
 
 /// Spawns arena barriers
 pub fn spawn_barrier_system(mut commands: Commands) {
-    commands
-        .spawn()
-        .insert_bundle(RigidBodyBundle {
-            body_type: RigidBodyType::Static,
-            position: Vec2::new(0.0, -38.0).into(),
-            ..Default::default()
-        })
-        .insert_bundle(ColliderBundle {
-            shape: ColliderShape::cuboid(48.0, 2.0),
-            material: ColliderMaterial {
-                friction: 0.0,
-                restitution: 1.0,
-                ..Default::default()
-            },
-            ..Default::default()
-        })
-        .insert(RigidBodyPositionSync::Discrete)
-        .insert(ColliderDebugRender::with_id(0));
+    spawn_barrier(&mut commands, 0.0, 38.0, 96.0, 4.0);
+    spawn_barrier(&mut commands, 0.0, -38.0, 96.0, 4.0);
+    spawn_barrier(&mut commands, 50.0, 0.0, 4.0, 72.0);
+    spawn_barrier(&mut commands, -50.0, 0.0, 4.0, 72.0);
+}
 
+/// Spawns an arena barrier
+fn spawn_barrier(commands: &mut Commands, x: f32, y: f32, width: f32, height: f32) {
     commands
         .spawn()
         .insert_bundle(RigidBodyBundle {
             body_type: RigidBodyType::Static,
-            position: Vec2::new(0.0, 38.0).into(),
+            position: Vec2::new(x, y).into(),
             ..Default::default()
         })
         .insert_bundle(ColliderBundle {
-            shape: ColliderShape::cuboid(48.0, 2.0),
-            material: ColliderMaterial {
-                friction: 0.0,
-                restitution: 1.0,
-                ..Default::default()
-            },
-            ..Default::default()
-        })
-        .insert(RigidBodyPositionSync::Discrete)
-        .insert(ColliderDebugRender::with_id(0));
-
-    commands
-        .spawn()
-        .insert_bundle(RigidBodyBundle {
-            body_type: RigidBodyType::Static,
-            position: Vec2::new(50.0, 0.0).into(),
-            ..Default::default()
-        })
-        .insert_bundle(ColliderBundle {
-            shape: ColliderShape::cuboid(2.0, 36.0),
-            material: ColliderMaterial {
-                friction: 0.0,
-                restitution: 1.0,
-                ..Default::default()
-            },
-            ..Default::default()
-        })
-        .insert(RigidBodyPositionSync::Discrete)
-        .insert(ColliderDebugRender::with_id(0));
-
-    commands
-        .spawn()
-        .insert_bundle(RigidBodyBundle {
-            body_type: RigidBodyType::Static,
-            position: Vec2::new(-50.0, 0.0).into(),
-            ..Default::default()
-        })
-        .insert_bundle(ColliderBundle {
-            shape: ColliderShape::cuboid(2.0, 36.0),
+            shape: ColliderShape::cuboid(width / 2.0, height / 2.0),
             material: ColliderMaterial {
                 friction: 0.0,
                 restitution: 1.0,

--- a/src/misc/spawn.rs
+++ b/src/misc/spawn.rs
@@ -12,9 +12,14 @@ pub fn spawn_barrier_system(mut commands: Commands) {
         })
         .insert_bundle(ColliderBundle {
             shape: ColliderShape::cuboid(48.0, 2.0),
+            material: ColliderMaterial {
+                friction: 0.0,
+                restitution: 1.0,
+                ..Default::default()
+            },
             ..Default::default()
         })
-        .insert(ColliderPositionSync::Discrete)
+        .insert(RigidBodyPositionSync::Discrete)
         .insert(ColliderDebugRender::with_id(0));
 
     commands
@@ -26,9 +31,14 @@ pub fn spawn_barrier_system(mut commands: Commands) {
         })
         .insert_bundle(ColliderBundle {
             shape: ColliderShape::cuboid(48.0, 2.0),
+            material: ColliderMaterial {
+                friction: 0.0,
+                restitution: 1.0,
+                ..Default::default()
+            },
             ..Default::default()
         })
-        .insert(ColliderPositionSync::Discrete)
+        .insert(RigidBodyPositionSync::Discrete)
         .insert(ColliderDebugRender::with_id(0));
 
     commands
@@ -40,9 +50,14 @@ pub fn spawn_barrier_system(mut commands: Commands) {
         })
         .insert_bundle(ColliderBundle {
             shape: ColliderShape::cuboid(2.0, 36.0),
+            material: ColliderMaterial {
+                friction: 0.0,
+                restitution: 1.0,
+                ..Default::default()
+            },
             ..Default::default()
         })
-        .insert(ColliderPositionSync::Discrete)
+        .insert(RigidBodyPositionSync::Discrete)
         .insert(ColliderDebugRender::with_id(0));
 
     commands
@@ -54,8 +69,13 @@ pub fn spawn_barrier_system(mut commands: Commands) {
         })
         .insert_bundle(ColliderBundle {
             shape: ColliderShape::cuboid(2.0, 36.0),
+            material: ColliderMaterial {
+                friction: 0.0,
+                restitution: 1.0,
+                ..Default::default()
+            },
             ..Default::default()
         })
-        .insert(ColliderPositionSync::Discrete)
+        .insert(RigidBodyPositionSync::Discrete)
         .insert(ColliderDebugRender::with_id(0));
 }

--- a/src/misc/spawn.rs
+++ b/src/misc/spawn.rs
@@ -3,19 +3,19 @@ use bevy_rapier2d::prelude::*;
 
 /// Spawns arena barriers
 pub fn spawn_barrier_system(mut commands: Commands) {
-    spawn_barrier(&mut commands, 0.0, 38.0, 96.0, 4.0);
-    spawn_barrier(&mut commands, 0.0, -38.0, 96.0, 4.0);
-    spawn_barrier(&mut commands, 50.0, 0.0, 4.0, 72.0);
-    spawn_barrier(&mut commands, -50.0, 0.0, 4.0, 72.0);
+    spawn_barrier(&mut commands, Vec2::new(0.0, 38.0), 96.0, 4.0);
+    spawn_barrier(&mut commands, Vec2::new(0.0, -38.0), 96.0, 4.0);
+    spawn_barrier(&mut commands, Vec2::new(50.0, 0.0), 4.0, 72.0);
+    spawn_barrier(&mut commands, Vec2::new(-50.0, 0.0), 4.0, 72.0);
 }
 
 /// Spawns an arena barrier
-fn spawn_barrier(commands: &mut Commands, x: f32, y: f32, width: f32, height: f32) {
+fn spawn_barrier(commands: &mut Commands, position: Vec2, width: f32, height: f32) {
     commands
         .spawn()
         .insert_bundle(RigidBodyBundle {
             body_type: RigidBodyType::Static,
-            position: Vec2::new(x, y).into(),
+            position: position.into(),
             ..Default::default()
         })
         .insert_bundle(ColliderBundle {

--- a/src/misc/spawn.rs
+++ b/src/misc/spawn.rs
@@ -1,0 +1,61 @@
+use bevy::prelude::*;
+use bevy_rapier2d::prelude::*;
+
+/// Spawns arena barriers
+pub fn spawn_barrier_system(mut commands: Commands) {
+    commands
+        .spawn()
+        .insert_bundle(RigidBodyBundle {
+            body_type: RigidBodyType::Static,
+            position: Vec2::new(0.0, -38.0).into(),
+            ..Default::default()
+        })
+        .insert_bundle(ColliderBundle {
+            shape: ColliderShape::cuboid(48.0, 2.0),
+            ..Default::default()
+        })
+        .insert(ColliderPositionSync::Discrete)
+        .insert(ColliderDebugRender::with_id(0));
+
+    commands
+        .spawn()
+        .insert_bundle(RigidBodyBundle {
+            body_type: RigidBodyType::Static,
+            position: Vec2::new(0.0, 38.0).into(),
+            ..Default::default()
+        })
+        .insert_bundle(ColliderBundle {
+            shape: ColliderShape::cuboid(48.0, 2.0),
+            ..Default::default()
+        })
+        .insert(ColliderPositionSync::Discrete)
+        .insert(ColliderDebugRender::with_id(0));
+
+    commands
+        .spawn()
+        .insert_bundle(RigidBodyBundle {
+            body_type: RigidBodyType::Static,
+            position: Vec2::new(50.0, 0.0).into(),
+            ..Default::default()
+        })
+        .insert_bundle(ColliderBundle {
+            shape: ColliderShape::cuboid(2.0, 36.0),
+            ..Default::default()
+        })
+        .insert(ColliderPositionSync::Discrete)
+        .insert(ColliderDebugRender::with_id(0));
+
+    commands
+        .spawn()
+        .insert_bundle(RigidBodyBundle {
+            body_type: RigidBodyType::Static,
+            position: Vec2::new(-50.0, 0.0).into(),
+            ..Default::default()
+        })
+        .insert_bundle(ColliderBundle {
+            shape: ColliderShape::cuboid(2.0, 36.0),
+            ..Default::default()
+        })
+        .insert(ColliderPositionSync::Discrete)
+        .insert(ColliderDebugRender::with_id(0));
+}

--- a/src/player/components/player.rs
+++ b/src/player/components/player.rs
@@ -2,12 +2,10 @@ use bevy::prelude::*;
 
 /// Component for managing core attributes of the player
 pub struct PlayerComponent {
+    /// Acceleration of the player
     pub acceleration: Vec2,
+    /// Deceleration of the player
     pub deceleration: Vec2,
-    pub speed: Vec2, // Amount of money the player has
-                     //pub money: i32,
-                     // Amount of collision damage the player deals
-                     //pub collision_damage: f32,
-                     // All the items the player has collected
-                     //pub items: Vec<ItemType>
+    /// Maximum speed of the player
+    pub speed: Vec2,
 }

--- a/src/player/spawn.rs
+++ b/src/player/spawn.rs
@@ -7,7 +7,7 @@ pub fn spawn_player_system(
     mut commands: Commands,
     asset_server: Res<AssetServer>,
     mut materials: ResMut<Assets<ColorMaterial>>,
-    mut rapier_config: ResMut<RapierConfiguration>,
+    rapier_config: Res<RapierConfiguration>,
 ) {
     const SPRITE_SCALE: f32 = 3.0; // TODO: move to game parameters resource
 
@@ -33,11 +33,15 @@ pub fn spawn_player_system(
             ..Default::default()
         })
         .insert_bundle(ColliderBundle {
-            //position: [collider_size_x / 2.0, collider_size_y / 2.0].into(), // may need to adjust position when detecting collisions
             shape: ColliderShape::cuboid(collider_size_x / 2.0, collider_size_y / 2.0),
+            material: ColliderMaterial {
+                friction: 0.0,
+                restitution: 1.0,
+                ..Default::default()
+            },
             ..Default::default()
         })
-        .insert(ColliderPositionSync::Discrete)
+        .insert(RigidBodyPositionSync::Discrete)
         .insert(ColliderDebugRender::with_id(1))
         .insert(PlayerComponent {
             // TODO: move values into game data file/resource for player

--- a/src/player/spawn.rs
+++ b/src/player/spawn.rs
@@ -7,7 +7,7 @@ pub fn spawn_player_system(
     mut commands: Commands,
     asset_server: Res<AssetServer>,
     mut materials: ResMut<Assets<ColorMaterial>>,
-    rapier_config: Res<RapierConfiguration>,
+    mut rapier_config: ResMut<RapierConfiguration>,
 ) {
     const SPRITE_SCALE: f32 = 3.0; // TODO: move to game parameters resource
 
@@ -27,6 +27,9 @@ pub fn spawn_player_system(
             ..Default::default()
         })
         .insert_bundle(RigidBodyBundle {
+            body_type: RigidBodyType::Dynamic,
+            mass_properties: RigidBodyMassPropsFlags::ROTATION_LOCKED.into(),
+            position: Vec2::new(0.0, 0.0).into(),
             ..Default::default()
         })
         .insert_bundle(ColliderBundle {


### PR DESCRIPTION
Barriers are in place on the boundary of the window (we can move the side ones in when we add the side panels). Had a chance to explore the colliders and rigidbodies with rapier. Noteable changes:

- Added four barriers on edges of window
- Gave barriers and player zero friction
- Gave barriers and player 1.0 restitution (bounciness)
- Locked rotation of player
- Made barriers static rigidbodies and the player a dynamic rigidbody