### PR TITLE
Add debug lines for colliders

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,10 +3,7 @@ name = "theta-wave"
 version = "0.1.7"
 edition = "2018"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 bevy = {version = "0.5", features = ["bevy_winit", "bevy_wgpu"]}
-# bevy_rapier2d = {version = "0.10.2", features = ["simd-stable", "render"] }
-bevy_rapier2d = { git = "https://github.com/dimforge/bevy_rapier", features = ["simd-stable", "render"] }
+bevy_rapier2d = {version = "0.10.2", features = ["simd-stable", "render"] }
 bevy_prototype_debug_lines = { git = "https://github.com/Toqozz/bevy_debug_lines"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,6 @@ edition = "2018"
 
 [dependencies]
 bevy = {version = "0.5", features = ["bevy_winit", "bevy_wgpu"]}
-bevy_rapier2d = {version = "0.10.2", features = ["simd-stable", "render"] }
-bevy_prototype_debug_lines = "0.3.2"
+# bevy_rapier2d = {version = "0.10.2", features = ["simd-stable", "render"] }
+bevy_rapier2d = { git = "https://github.com/dimforge/bevy_rapier", features = ["simd-stable", "render"] }
+bevy_prototype_debug_lines = { git = "https://github.com/Toqozz/bevy_debug_lines"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,4 @@ edition = "2018"
 [dependencies]
 bevy = {version = "0.5", features = ["bevy_winit", "bevy_wgpu"]}
 bevy_rapier2d = {version = "0.10.2", features = ["simd-stable", "render"] }
+bevy_prototype_debug_lines = "0.3.2"

--- a/config/display.ron
+++ b/config/display.ron
@@ -1,0 +1,5 @@
+(
+	width: 1280.0,
+	height: 720.0,
+	fullscreen: false,
+)

--- a/config/display.ron
+++ b/config/display.ron
@@ -1,5 +1,0 @@
-(
-	width: 1280.0,
-	height: 720.0,
-	fullscreen: false,
-)

--- a/src/debug/mod.rs
+++ b/src/debug/mod.rs
@@ -1,0 +1,95 @@
+//! `thetawave_lib` debug module
+use bevy::prelude::*;
+use bevy_prototype_debug_lines::*;
+use bevy_rapier2d::prelude::*;
+
+use crate::player::PlayerComponent;
+
+pub fn collider_debug_lines_system(
+    mut lines: ResMut<DebugLines>,
+    player_colliders: Query<(&ColliderPosition, &ColliderShape), With<PlayerComponent>>,
+) {
+    const RAPIER_CONFIG_SCALE: f32 = 10.0;
+
+    // draw colliders for players
+    for (collider_position, collider_shape) in player_colliders.iter() {
+        let collider_cuboid = collider_shape.as_cuboid().unwrap();
+        let collider_translation = collider_position.translation;
+
+        draw_debug_collider_cuboid(
+            &mut lines,
+            collider_cuboid,
+            collider_translation,
+            RAPIER_CONFIG_SCALE,
+        );
+    }
+}
+
+fn draw_debug_collider_cuboid(
+    debug_lines: &mut ResMut<DebugLines>,
+    cuboid: &Cuboid,
+    translation: Translation<f32>,
+    scale_multiplier: f32,
+) {
+    let half_extents = cuboid.half_extents;
+
+    // draw right side
+    let start = Vec3::new(
+        (translation.x + half_extents.x) * scale_multiplier,
+        (translation.y + half_extents.y) * scale_multiplier,
+        0.0,
+    );
+
+    let end = Vec3::new(
+        (translation.x + half_extents.x) * scale_multiplier,
+        (translation.y - half_extents.y) * scale_multiplier,
+        0.0,
+    );
+
+    debug_lines.line_colored(start, end, 0.0, Color::GREEN);
+
+    // draw left side
+    let start = Vec3::new(
+        (translation.x - half_extents.x) * scale_multiplier,
+        (translation.y - half_extents.y) * scale_multiplier,
+        0.0,
+    );
+
+    let end = Vec3::new(
+        (translation.x - half_extents.x) * scale_multiplier,
+        (translation.y + half_extents.y) * scale_multiplier,
+        0.0,
+    );
+
+    debug_lines.line_colored(start, end, 0.0, Color::GREEN);
+
+    // draw top side
+    let start = Vec3::new(
+        (translation.x + half_extents.x) * scale_multiplier,
+        (translation.y + half_extents.y) * scale_multiplier,
+        0.0,
+    );
+
+    let end = Vec3::new(
+        (translation.x - half_extents.x) * scale_multiplier,
+        (translation.y + half_extents.y) * scale_multiplier,
+        0.0,
+    );
+
+    debug_lines.line_colored(start, end, 0.0, Color::GREEN);
+
+    // draw bottom side
+    let start = Vec3::new(
+        (translation.x + half_extents.x) * scale_multiplier,
+        (translation.y - half_extents.y) * scale_multiplier,
+        0.0,
+    );
+
+    let end = Vec3::new(
+        (translation.x - half_extents.x) * scale_multiplier,
+        (translation.y - half_extents.y) * scale_multiplier,
+        0.0,
+    );
+
+    debug_lines.line_colored(start, end, 0.0, Color::GREEN);
+}

--- a/src/debug/mod.rs
+++ b/src/debug/mod.rs
@@ -3,15 +3,13 @@ use bevy::prelude::*;
 use bevy_prototype_debug_lines::*;
 use bevy_rapier2d::prelude::*;
 
-use crate::player::PlayerComponent;
-
 pub fn collider_debug_lines_system(
     mut lines: ResMut<DebugLines>,
-    player_colliders: Query<(&ColliderPosition, &ColliderShape), With<PlayerComponent>>,
+    player_colliders: Query<(&ColliderPosition, &ColliderShape)>,
 ) {
     const RAPIER_CONFIG_SCALE: f32 = 10.0;
 
-    // draw colliders for players
+    // draw colliders
     for (collider_position, collider_shape) in player_colliders.iter() {
         let collider_cuboid = collider_shape.as_cuboid().unwrap();
         let collider_translation = collider_position.translation;

--- a/src/debug/mod.rs
+++ b/src/debug/mod.rs
@@ -6,9 +6,8 @@ use bevy_rapier2d::prelude::*;
 pub fn collider_debug_lines_system(
     mut lines: ResMut<DebugLines>,
     player_colliders: Query<(&ColliderPosition, &ColliderShape)>,
+    rapier_config: Res<RapierConfiguration>,
 ) {
-    const RAPIER_CONFIG_SCALE: f32 = 10.0;
-
     // draw colliders
     for (collider_position, collider_shape) in player_colliders.iter() {
         let collider_cuboid = collider_shape.as_cuboid().unwrap();
@@ -18,7 +17,7 @@ pub fn collider_debug_lines_system(
             &mut lines,
             collider_cuboid,
             collider_translation,
-            RAPIER_CONFIG_SCALE,
+            rapier_config.scale,
         );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,24 +7,29 @@ mod misc;
 mod player;
 
 fn main() {
-    App::build()
-        .insert_resource(WindowDescriptor {
-            title: "Theta Wave".to_string(),
-            width: 960.0,
-            height: 720.0,
-            ..Default::default()
-        })
-        .add_plugins(DefaultPlugins)
-        .add_plugin(RapierPhysicsPlugin::<NoUserData>::default())
-        .add_plugin(DebugLinesPlugin)
-        //.add_plugin(RapierRenderPlugin)
-        .add_startup_system(setup_game.system().label("init"))
-        .add_startup_system(misc::spawn_barrier_system.system().after("init"))
-        .add_startup_system(player::spawn_player_system.system().after("init"))
-        .add_system(player::player_movement_system.system())
-        .add_system(debug::collider_debug_lines_system.system())
-        //.add_system(print_player_position.system())
-        .run();
+    let mut app = App::build();
+
+    app.insert_resource(WindowDescriptor {
+        title: "Theta Wave".to_string(),
+        width: 960.0,
+        height: 720.0,
+        ..Default::default()
+    })
+    .add_plugins(DefaultPlugins)
+    .add_plugin(RapierPhysicsPlugin::<NoUserData>::default())
+    .add_plugin(DebugLinesPlugin)
+    //.add_plugin(RapierRenderPlugin)
+    .add_startup_system(setup_game.system().label("init"))
+    .add_startup_system(misc::spawn_barrier_system.system().after("init"))
+    .add_startup_system(player::spawn_player_system.system().after("init"))
+    .add_system(player::player_movement_system.system());
+    //.add_system(print_player_position.system())
+
+    if cfg!(debug_assertions) {
+        app.add_system(debug::collider_debug_lines_system.system());
+    }
+
+    app.run();
 }
 
 fn setup_game(mut commands: Commands, mut rapier_config: ResMut<RapierConfiguration>) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,8 @@
 use bevy::prelude::*;
+use bevy_prototype_debug_lines::*;
 use bevy_rapier2d::{na::Vector2, prelude::*};
 
+mod debug;
 mod misc;
 mod player;
 
@@ -14,12 +16,18 @@ fn main() {
         })
         .add_plugins(DefaultPlugins)
         .add_plugin(RapierPhysicsPlugin::<NoUserData>::default())
+        .add_plugin(DebugLinesPlugin)
         //.add_plugin(RapierRenderPlugin)
         .add_startup_system(setup_game.system().label("init"))
         .add_startup_system(misc::spawn_barrier_system.system().after("init"))
         .add_startup_system(player::spawn_player_system.system().after("init"))
-        .add_system(player::player_movement_system.system())
-        .add_system(print_player_position.system())
+        .add_system(player::player_movement_system.system().label("movement"))
+        .add_system(
+            debug::collider_debug_lines_system
+                .system()
+                .after("movement"),
+        )
+        //.add_system(print_player_position.system())
         .run();
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,12 +21,8 @@ fn main() {
         .add_startup_system(setup_game.system().label("init"))
         .add_startup_system(misc::spawn_barrier_system.system().after("init"))
         .add_startup_system(player::spawn_player_system.system().after("init"))
-        .add_system(player::player_movement_system.system().label("movement"))
-        .add_system(
-            debug::collider_debug_lines_system
-                .system()
-                .after("movement"),
-        )
+        .add_system(player::player_movement_system.system())
+        .add_system(debug::collider_debug_lines_system.system())
         //.add_system(print_player_position.system())
         .run();
 }

--- a/src/player/spawn.rs
+++ b/src/player/spawn.rs
@@ -41,7 +41,7 @@ pub fn spawn_player_system(
             },
             ..Default::default()
         })
-        .insert(RigidBodyPositionSync::Discrete)
+        .insert(ColliderPositionSync::Discrete)
         .insert(ColliderDebugRender::with_id(1))
         .insert(PlayerComponent {
             // TODO: move values into game data file/resource for player


### PR DESCRIPTION
Added debug lines using https://github.com/toqozz/bevy_debug_lines

There is still an issue with the debug lines being drawn before the rapier computes the position of the player, but for now, this is fine.

Debug lines only appear in debug builds (not with `cargo run --release`).

#5 