### PR TITLE
Slightly more portable use of project directories for sqlite file path

### DIFF
--- a/crates/thetawave_storage/Cargo.toml
+++ b/crates/thetawave_storage/Cargo.toml
@@ -10,7 +10,7 @@ bevy = {workspace = true}
 thiserror = {workspace = true}
 derive_more = {workspace = true}
 rusqlite = { version = "0.29.0", features = ["bundled"] }
-dirs = "5.0.1"
+directories = "5.0.1"
 thetawave_interface = {path = "../thetawave_interface"}
 
 [dev-dependencies]

--- a/crates/thetawave_storage/src/core.rs
+++ b/crates/thetawave_storage/src/core.rs
@@ -1,5 +1,5 @@
 use bevy::prelude::info;
-use dirs::data_dir;
+use directories::ProjectDirs;
 use rusqlite;
 use rusqlite::Connection;
 use std::env::var_os;
@@ -28,10 +28,14 @@ pub(super) enum OurDBError {
 }
 
 fn default_db_path() -> Result<PathBuf, OurDBError> {
-    let data_dir = data_dir().ok_or(OurDBError::NoDBPathFound)?;
-    let game_data_dir = data_dir.join("thetawave");
-    std::fs::create_dir_all(&game_data_dir)?;
-    Ok(game_data_dir.join(THETAWAVE_DB_FILE))
+    match ProjectDirs::from("org", "thetawave-game", "thetawave") {
+        Some(pdirs) => {
+            let game_data_dir = pdirs.data_local_dir();
+            std::fs::create_dir_all(&game_data_dir)?;
+            Ok(game_data_dir.join(THETAWAVE_DB_FILE))
+        }
+        None => Err(OurDBError::NoDBPathFound),
+    }
 }
 
 pub(super) fn setup_db(conn: Connection) -> rusqlite::Result<()> {


### PR DESCRIPTION
 by using the `directories` crate vs the lower leveled `dirs` crate. 

from [the docs](https://github.com/dirs-dev/dirs-rs)

> It's mid-level sister library, directories, is available for Rust ([directories-rs](https://github.com/dirs-dev/directories-rs)) and on the JVM ([directories-jvm](https://github.com/dirs-dev/directories-jvm)).