### PR TITLE
Damage Number Effect

### DIFF
--- a/assets/consumable_assets.assets.ron
+++ b/assets/consumable_assets.assets.ron
@@ -6,13 +6,6 @@
         columns: 1,
         rows: 1,  
     ),
-    "defense_wrench": TextureAtlas (
-        path: "texture/defense_wrench_spritesheet.png",
-        tile_size_x: 12.,
-        tile_size_y: 12.,
-        columns: 1,
-        rows: 1,  
-    ),
     "money3": TextureAtlas (
         path: "texture/money5_spritesheet.png",
         tile_size_x: 10.,

--- a/assets/data/effects.ron
+++ b/assets/data/effects.ron
@@ -98,4 +98,124 @@
 			frame_duration: 0.1,
 		),
 	),
+	Text(DamageDealt): (
+		effect_type: Text(DamageDealt),
+		effect_behaviors: [FadeOutMs((
+			mode: Once,
+			duration: (
+				secs: 0,
+				nanos: 550000000,
+			),
+			stopwatch: (
+				elapsed: (
+					secs: 0,
+					nanos: 0,
+				),
+				paused: false, 
+			),
+			finished: false,
+			times_finished_this_tick: 0,
+		))],
+		z_level: 10.0,
+		animation: (
+			direction: None,
+			frame_duration: 0.1,
+		),
+	),
+	Text(ConsumableCollected(Money1)): (
+		effect_type: Text(ConsumableCollected(Money1)),
+		effect_behaviors: [FadeOutMs((
+			mode: Once,
+			duration: (
+				secs: 0,
+				nanos: 550000000,
+			),
+			stopwatch: (
+				elapsed: (
+					secs: 0,
+					nanos: 0,
+				),
+				paused: false, 
+			),
+			finished: false,
+			times_finished_this_tick: 0,
+		))],
+		z_level: 10.0,
+		animation: (
+			direction: None,
+			frame_duration: 0.1,
+		),
+	),
+	Text(ConsumableCollected(Money3)): (
+		effect_type: Text(ConsumableCollected(Money3)),
+		effect_behaviors: [FadeOutMs((
+			mode: Once,
+			duration: (
+				secs: 0,
+				nanos: 550000000,
+			),
+			stopwatch: (
+				elapsed: (
+					secs: 0,
+					nanos: 0,
+				),
+				paused: false, 
+			),
+			finished: false,
+			times_finished_this_tick: 0,
+		))],
+		z_level: 10.0,
+		animation: (
+			direction: None,
+			frame_duration: 0.1,
+		),
+	),
+	Text(ConsumableCollected(HealthWrench)): (
+		effect_type: Text(ConsumableCollected(HealthWrench)),
+		effect_behaviors: [FadeOutMs((
+			mode: Once,
+			duration: (
+				secs: 0,
+				nanos: 550000000,
+			),
+			stopwatch: (
+				elapsed: (
+					secs: 0,
+					nanos: 0,
+				),
+				paused: false, 
+			),
+			finished: false,
+			times_finished_this_tick: 0,
+		))],
+		z_level: 10.0,
+		animation: (
+			direction: None,
+			frame_duration: 0.1,
+		),
+	),
+	Text(ConsumableCollected(Armor)): (
+		effect_type: Text(ConsumableCollected(Armor)),
+		effect_behaviors: [FadeOutMs((
+			mode: Once,
+			duration: (
+				secs: 0,
+				nanos: 550000000,
+			),
+			stopwatch: (
+				elapsed: (
+					secs: 0,
+					nanos: 0,
+				),
+				paused: false, 
+			),
+			finished: false,
+			times_finished_this_tick: 0,
+		))],
+		z_level: 10.0,
+		animation: (
+			direction: None,
+			frame_duration: 0.1,
+		),
+	),
 }

--- a/assets/data/text_effects.ron
+++ b/assets/data/text_effects.ron
@@ -1,0 +1,72 @@
+{
+    DamageDealt: (
+        text: "",
+        text_color: Rgba(red: 1.0, green: 1.0, blue: 1.0, alpha: 1.0),
+        font_size: 60.0,
+        translation_x: (
+            start: -45.0,
+            end: 45.0,
+        ),
+        translation_y: (
+            start: -45.0,
+            end: 45.0,
+        ),
+        scale: 0.4,
+    ),
+    ConsumableCollected(Money1): (
+        text: "Fire Rate +",
+        text_color: Rgba(red: 0.0, green: 1.0, blue: 0.0, alpha: 1.0),
+        font_size: 60.0,
+        translation_x: (
+            start: -45.0,
+            end: 45.0,
+        ),
+        translation_y: (
+            start: -45.0,
+            end: 45.0,
+        ),
+        scale: 0.4,
+    ),
+    ConsumableCollected(Money3): (
+        text: "Fire Rate +++",
+        text_color: Rgba(red: 0.0, green: 1.0, blue: 0.0, alpha: 1.0),
+        font_size: 60.0,
+        translation_x: (
+            start: -45.0,
+            end: 45.0,
+        ),
+        translation_y: (
+            start: -45.0,
+            end: 45.0,
+        ),
+        scale: 0.4,
+    ),
+    ConsumableCollected(HealthWrench): (
+        text: "Health +",
+        text_color: Rgba(red: 0.0, green: 1.0, blue: 0.0, alpha: 1.0),
+        font_size: 60.0,
+        translation_x: (
+            start: -45.0,
+            end: 45.0,
+        ),
+        translation_y: (
+            start: -45.0,
+            end: 45.0,
+        ),
+        scale: 0.4,
+    ),
+    ConsumableCollected(Armor): (
+        text: "Armor +",
+        text_color: Rgba(red: 0.0, green: 1.0, blue: 0.0, alpha: 1.0),
+        font_size: 60.0,
+        translation_x: (
+            start: -45.0,
+            end: 45.0,
+        ),
+        translation_y: (
+            start: -45.0,
+            end: 45.0,
+        ),
+        scale: 0.4,
+    ),
+}

--- a/crates/thetawave_interface/src/health.rs
+++ b/crates/thetawave_interface/src/health.rs
@@ -1,0 +1,8 @@
+use bevy_ecs::prelude::Entity;
+use bevy_ecs_macros::Event;
+
+#[derive(Event)]
+pub struct DamageDealtEvent {
+    pub damage: f32,
+    pub target: Entity,
+}

--- a/crates/thetawave_interface/src/lib.rs
+++ b/crates/thetawave_interface/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod character_selection;
 pub mod game;
+pub mod health;
 pub mod spawnable;
 pub mod states;

--- a/crates/thetawave_interface/src/spawnable.rs
+++ b/crates/thetawave_interface/src/spawnable.rs
@@ -134,7 +134,7 @@ pub enum EffectType {
     AllyBlastExplosion,
     AllyBlastDespawn,
     #[default]
-    MobExplosion,
+    MobExplosion, // defaults to mob explosion
     ConsumableDespawn,
     EnemyBlastExplosion,
     EnemyBlastDespawn,
@@ -147,6 +147,7 @@ pub enum EffectType {
     //Giblets(MobType),
 }
 
+/// Subtype of effect for text effects
 #[derive(Deserialize, Debug, Hash, PartialEq, Eq, Clone, Display)]
 pub enum TextEffectType {
     DamageDealt,

--- a/crates/thetawave_interface/src/spawnable.rs
+++ b/crates/thetawave_interface/src/spawnable.rs
@@ -1,3 +1,5 @@
+use std::default;
+
 use serde::Deserialize;
 use strum_macros::{Display, EnumString};
 
@@ -127,10 +129,11 @@ pub enum ItemType {
 }
 
 /// Type that encompasses all spawnable effects
-#[derive(Deserialize, Debug, Hash, PartialEq, Eq, Clone, Display)]
+#[derive(Deserialize, Debug, Hash, PartialEq, Eq, Clone, Display, Default)]
 pub enum EffectType {
     AllyBlastExplosion,
     AllyBlastDespawn,
+    #[default]
     MobExplosion,
     ConsumableDespawn,
     EnemyBlastExplosion,

--- a/crates/thetawave_interface/src/spawnable.rs
+++ b/crates/thetawave_interface/src/spawnable.rs
@@ -134,6 +134,7 @@ pub enum EffectType {
     AllyBulletDespawn,
     EnemyBulletDespawn,
     AllyBulletExplosion,
+    DamageNumber(usize),
     //PoisonBlastExplosion,
     //CriticalBlastExplosion,
     //MobExplosion,

--- a/crates/thetawave_interface/src/spawnable.rs
+++ b/crates/thetawave_interface/src/spawnable.rs
@@ -134,7 +134,7 @@ pub enum EffectType {
     AllyBulletDespawn,
     EnemyBulletDespawn,
     AllyBulletExplosion,
-    DamageNumber(usize),
+    DamageText(String),
     //PoisonBlastExplosion,
     //CriticalBlastExplosion,
     //MobExplosion,

--- a/crates/thetawave_interface/src/spawnable.rs
+++ b/crates/thetawave_interface/src/spawnable.rs
@@ -93,7 +93,6 @@ pub enum NeutralMobType {
 /// Type that encompasses all spawnable consumables
 #[derive(Deserialize, Debug, Hash, PartialEq, Eq, Clone, Display)]
 pub enum ConsumableType {
-    DefenseWrench,
     Money1,
     Money3,
     HealthWrench,
@@ -134,6 +133,12 @@ pub enum EffectType {
     AllyBulletDespawn,
     EnemyBulletDespawn,
     AllyBulletExplosion,
-    DamageText(String),
+    Text(TextEffectType),
     //Giblets(MobType),
+}
+
+#[derive(Deserialize, Debug, Hash, PartialEq, Eq, Clone, Display)]
+pub enum TextEffectType {
+    DamageDealt,
+    ConsumableCollected(ConsumableType),
 }

--- a/crates/thetawave_interface/src/spawnable.rs
+++ b/crates/thetawave_interface/src/spawnable.rs
@@ -135,8 +135,5 @@ pub enum EffectType {
     EnemyBulletDespawn,
     AllyBulletExplosion,
     DamageText(String),
-    //PoisonBlastExplosion,
-    //CriticalBlastExplosion,
-    //MobExplosion,
     //Giblets(MobType),
 }

--- a/crates/thetawave_interface/src/spawnable.rs
+++ b/crates/thetawave_interface/src/spawnable.rs
@@ -144,7 +144,6 @@ pub enum EffectType {
     EnemyBulletDespawn,
     AllyBulletExplosion,
     Text(TextEffectType),
-    //Giblets(MobType),
 }
 
 /// Subtype of effect for text effects

--- a/crates/thetawave_interface/src/spawnable.rs
+++ b/crates/thetawave_interface/src/spawnable.rs
@@ -27,6 +27,13 @@ pub enum SpawnableType {
     MobSegment(MobSegmentType),
 }
 
+impl Default for SpawnableType {
+    /// Money1 is default so that SpawnableComponent can derive default
+    fn default() -> Self {
+        SpawnableType::Consumable(ConsumableType::Money1)
+    }
+}
+
 /// Type that encompasses all weapon projectiles
 #[derive(Deserialize, Debug, Hash, PartialEq, Eq, Clone, Display)]
 pub enum ProjectileType {

--- a/src/arena/barrier.rs
+++ b/src/arena/barrier.rs
@@ -36,8 +36,7 @@ pub fn spawn_barriers_system(
             scale: Vec3::new(10.0, game_parameters.sprite_scale, 1.0),
             ..Default::default()
         },
-        initial_motion: InitialMotion::default(),
-        text: None,
+        ..default()
     });
     spawn_effect.send(SpawnEffectEvent {
         effect_type: EffectType::BarrierGlow,
@@ -46,8 +45,7 @@ pub fn spawn_barriers_system(
             scale: Vec3::new(10.0, game_parameters.sprite_scale, 1.0),
             ..Default::default()
         },
-        initial_motion: InitialMotion::default(),
-        text: None,
+        ..default()
     });
     spawn_effect.send(SpawnEffectEvent {
         effect_type: EffectType::BarrierGlow,
@@ -56,8 +54,7 @@ pub fn spawn_barriers_system(
             scale: Vec3::new(7.3, game_parameters.sprite_scale, 1.0),
             rotation: Quat::from_rotation_z(FRAC_PI_2),
         },
-        initial_motion: InitialMotion::default(),
-        text: None,
+        ..default()
     });
     spawn_effect.send(SpawnEffectEvent {
         effect_type: EffectType::BarrierGlow,
@@ -66,8 +63,7 @@ pub fn spawn_barriers_system(
             scale: Vec3::new(7.3, game_parameters.sprite_scale, 1.0),
             rotation: Quat::from_rotation_z(FRAC_PI_2),
         },
-        initial_motion: InitialMotion::default(),
-        text: None,
+        ..default()
     });
 }
 

--- a/src/arena/barrier.rs
+++ b/src/arena/barrier.rs
@@ -37,6 +37,7 @@ pub fn spawn_barriers_system(
             ..Default::default()
         },
         initial_motion: InitialMotion::default(),
+        text: None,
     });
     spawn_effect.send(SpawnEffectEvent {
         effect_type: EffectType::BarrierGlow,
@@ -46,6 +47,7 @@ pub fn spawn_barriers_system(
             ..Default::default()
         },
         initial_motion: InitialMotion::default(),
+        text: None,
     });
     spawn_effect.send(SpawnEffectEvent {
         effect_type: EffectType::BarrierGlow,
@@ -55,6 +57,7 @@ pub fn spawn_barriers_system(
             rotation: Quat::from_rotation_z(FRAC_PI_2),
         },
         initial_motion: InitialMotion::default(),
+        text: None,
     });
     spawn_effect.send(SpawnEffectEvent {
         effect_type: EffectType::BarrierGlow,
@@ -64,6 +67,7 @@ pub fn spawn_barriers_system(
             rotation: Quat::from_rotation_z(FRAC_PI_2),
         },
         initial_motion: InitialMotion::default(),
+        text: None,
     });
 }
 

--- a/src/assets/consumable.rs
+++ b/src/assets/consumable.rs
@@ -7,8 +7,6 @@ use thetawave_interface::spawnable::ConsumableType;
 pub struct ConsumableAssets {
     #[asset(key = "health_wrench")]
     pub health_wrench: Handle<TextureAtlas>,
-    #[asset(key = "defense_wrench")]
-    pub defense_wrench: Handle<TextureAtlas>,
     #[asset(key = "money3")]
     pub money3: Handle<TextureAtlas>,
     #[asset(key = "money1")]
@@ -20,7 +18,6 @@ pub struct ConsumableAssets {
 impl ConsumableAssets {
     pub fn get_asset(&self, consumable_type: &ConsumableType) -> Handle<TextureAtlas> {
         match consumable_type {
-            ConsumableType::DefenseWrench => self.defense_wrench.clone(),
             ConsumableType::Money1 => self.money1.clone(),
             ConsumableType::Money3 => self.money3.clone(),
             ConsumableType::HealthWrench => self.health_wrench.clone(),

--- a/src/assets/effect.rs
+++ b/src/assets/effect.rs
@@ -43,6 +43,7 @@ impl EffectAssets {
             EffectType::EnemyBulletDespawn => self.enemy_bullet_despawn.clone(),
             EffectType::AllyBulletExplosion => self.ally_bullet_explosion.clone(),
             EffectType::EnemyBulletExplosion => self.enemy_bullet_explosion.clone(),
+            EffectType::DamageNumber(_) => todo!(),
         }
     }
 }

--- a/src/assets/effect.rs
+++ b/src/assets/effect.rs
@@ -30,20 +30,20 @@ pub struct EffectAssets {
 }
 
 impl EffectAssets {
-    pub fn get_asset(&self, effect_type: &EffectType) -> Handle<TextureAtlas> {
+    pub fn get_asset(&self, effect_type: &EffectType) -> Option<Handle<TextureAtlas>> {
         match effect_type {
-            EffectType::AllyBlastExplosion => self.ally_blast_explosion.clone(),
-            EffectType::AllyBlastDespawn => self.ally_blast_despawn.clone(),
-            EffectType::MobExplosion => self.mob_explosion.clone(),
-            EffectType::ConsumableDespawn => self.consumable_despawn.clone(),
-            EffectType::EnemyBlastExplosion => self.enemy_blast_explosion.clone(),
-            EffectType::EnemyBlastDespawn => self.enemy_blast_despawn.clone(),
-            EffectType::BarrierGlow => self.barrier_glow.clone(),
-            EffectType::AllyBulletDespawn => self.ally_bullet_despawn.clone(),
-            EffectType::EnemyBulletDespawn => self.enemy_bullet_despawn.clone(),
-            EffectType::AllyBulletExplosion => self.ally_bullet_explosion.clone(),
-            EffectType::EnemyBulletExplosion => self.enemy_bullet_explosion.clone(),
-            EffectType::DamageText(_) => todo!(),
+            EffectType::AllyBlastExplosion => Some(self.ally_blast_explosion.clone()),
+            EffectType::AllyBlastDespawn => Some(self.ally_blast_despawn.clone()),
+            EffectType::MobExplosion => Some(self.mob_explosion.clone()),
+            EffectType::ConsumableDespawn => Some(self.consumable_despawn.clone()),
+            EffectType::EnemyBlastExplosion => Some(self.enemy_blast_explosion.clone()),
+            EffectType::EnemyBlastDespawn => Some(self.enemy_blast_despawn.clone()),
+            EffectType::BarrierGlow => Some(self.barrier_glow.clone()),
+            EffectType::AllyBulletDespawn => Some(self.ally_bullet_despawn.clone()),
+            EffectType::EnemyBulletDespawn => Some(self.enemy_bullet_despawn.clone()),
+            EffectType::AllyBulletExplosion => Some(self.ally_bullet_explosion.clone()),
+            EffectType::EnemyBulletExplosion => Some(self.enemy_bullet_explosion.clone()),
+            EffectType::Text(_) => None,
         }
     }
 }

--- a/src/assets/effect.rs
+++ b/src/assets/effect.rs
@@ -43,7 +43,7 @@ impl EffectAssets {
             EffectType::EnemyBulletDespawn => self.enemy_bullet_despawn.clone(),
             EffectType::AllyBulletExplosion => self.ally_bullet_explosion.clone(),
             EffectType::EnemyBulletExplosion => self.enemy_bullet_explosion.clone(),
-            EffectType::DamageNumber(_) => todo!(),
+            EffectType::DamageText(_) => todo!(),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -138,6 +138,7 @@ fn main() {
     .add_plugins(animation::AnimationPlugin)
     .add_plugins(states::StatesPlugin)
     .add_plugins(game::counters::plugin::CountingMetricsPlugin)
+    .add_plugins(misc::HealthPlugin)
     .insert_resource(ClearColor(Color::BLACK))
     .insert_resource(AmbientLight {
         color: Color::WHITE,

--- a/src/misc/health.rs
+++ b/src/misc/health.rs
@@ -1,14 +1,11 @@
 use bevy::prelude::*;
 use serde::Deserialize;
-use thetawave_interface::spawnable::{EffectType, TextEffectType};
+use thetawave_interface::{
+    health::DamageDealtEvent,
+    spawnable::{EffectType, TextEffectType},
+};
 
 use crate::spawnable::{MobComponent, MobSegmentComponent, SpawnEffectEvent};
-
-#[derive(Event)]
-pub struct DamageDealtEvent {
-    pub damage: f32,
-    pub target: Entity,
-}
 
 pub fn damage_system(
     mut damge_dealt_event: EventReader<DamageDealtEvent>,

--- a/src/misc/mod.rs
+++ b/src/misc/mod.rs
@@ -1,7 +1,9 @@
 use bevy::prelude::*;
+use thetawave_interface::health::DamageDealtEvent;
 
 mod health;
-pub use self::health::{DamageDealtEvent, Health};
+
+pub use self::health::Health;
 
 pub struct HealthPlugin;
 

--- a/src/misc/mod.rs
+++ b/src/misc/mod.rs
@@ -1,3 +1,13 @@
-mod health;
+use bevy::prelude::*;
 
-pub use self::health::Health;
+mod health;
+pub use self::health::{DamageDealtEvent, Health};
+
+pub struct HealthPlugin;
+
+impl Plugin for HealthPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_event::<DamageDealtEvent>()
+            .add_systems(Update, health::damage_system);
+    }
+}

--- a/src/player/systems/mod.rs
+++ b/src/player/systems/mod.rs
@@ -55,8 +55,7 @@ pub fn player_death_system(
                     ),
                     ..Default::default()
                 },
-                initial_motion: InitialMotion::default(),
-                text: None,
+                ..default()
             });
 
             // play explosion sound effect

--- a/src/player/systems/mod.rs
+++ b/src/player/systems/mod.rs
@@ -56,6 +56,7 @@ pub fn player_death_system(
                     ..Default::default()
                 },
                 initial_motion: InitialMotion::default(),
+                text: None,
             });
 
             // play explosion sound effect

--- a/src/spawnable/consumable/behavior.rs
+++ b/src/spawnable/consumable/behavior.rs
@@ -10,7 +10,7 @@ use bevy::prelude::*;
 use bevy_kira_audio::prelude::*;
 use bevy_rapier2d::prelude::*;
 use serde::Deserialize;
-use thetawave_interface::spawnable::EffectType;
+use thetawave_interface::spawnable::{ConsumableType, EffectType, TextEffectType};
 
 use super::ConsumableEffect;
 
@@ -63,6 +63,7 @@ pub fn consumable_execute_behavior_system(
                         &audio_channel,
                         &audio_assets,
                         &game_parameters_res,
+                        consumable_component.consumable_type.clone(),
                     );
                 }
                 ConsumableBehavior::AttractToPlayer => {
@@ -133,6 +134,7 @@ fn apply_effects_on_impact(
     audio_channel: &AudioChannel<audio::SoundEffectsAudioChannel>,
     audio_assets: &GameAudioAssets,
     game_parameters_res: &GameParametersResource,
+    consumable_type: ConsumableType,
 ) {
     for collision_event in collision_events.iter() {
         if let SortedCollisionEvent::PlayerToConsumableIntersection {
@@ -155,6 +157,19 @@ fn apply_effects_on_impact(
                             1.0,
                         ),
                         ..Default::default()
+                    },
+                    initial_motion: InitialMotion::default(),
+                    text: None,
+                });
+
+                spawn_effect_event_writer.send(SpawnEffectEvent {
+                    effect_type: EffectType::Text(TextEffectType::ConsumableCollected(
+                        consumable_type.clone(),
+                    )),
+                    transform: Transform {
+                        translation: transform.translation,
+                        scale: transform.scale,
+                        ..default()
                     },
                     initial_motion: InitialMotion::default(),
                     text: None,

--- a/src/spawnable/consumable/behavior.rs
+++ b/src/spawnable/consumable/behavior.rs
@@ -3,7 +3,7 @@ use crate::{
     audio,
     collision::SortedCollisionEvent,
     game::GameParametersResource,
-    spawnable::{InitialMotion, PlayerComponent, SpawnEffectEvent},
+    spawnable::{PlayerComponent, SpawnEffectEvent},
 };
 use bevy::math::Vec3Swizzles;
 use bevy::prelude::*;
@@ -161,6 +161,7 @@ fn apply_effects_on_impact(
                     ..default()
                 });
 
+                // spawn consumable collected text
                 spawn_effect_event_writer.send(SpawnEffectEvent {
                     effect_type: EffectType::Text(TextEffectType::ConsumableCollected(
                         consumable_type.clone(),

--- a/src/spawnable/consumable/behavior.rs
+++ b/src/spawnable/consumable/behavior.rs
@@ -157,6 +157,7 @@ fn apply_effects_on_impact(
                         ..Default::default()
                     },
                     initial_motion: InitialMotion::default(),
+                    text: None,
                 });
 
                 //apply effect to player

--- a/src/spawnable/consumable/behavior.rs
+++ b/src/spawnable/consumable/behavior.rs
@@ -158,8 +158,7 @@ fn apply_effects_on_impact(
                         ),
                         ..Default::default()
                     },
-                    initial_motion: InitialMotion::default(),
-                    text: None,
+                    ..default()
                 });
 
                 spawn_effect_event_writer.send(SpawnEffectEvent {
@@ -171,8 +170,7 @@ fn apply_effects_on_impact(
                         scale: transform.scale,
                         ..default()
                     },
-                    initial_motion: InitialMotion::default(),
-                    text: None,
+                    ..default()
                 });
 
                 //apply effect to player

--- a/src/spawnable/effect/behavior.rs
+++ b/src/spawnable/effect/behavior.rs
@@ -7,10 +7,11 @@ use super::EffectComponent;
 #[derive(Deserialize, Clone)]
 pub enum EffectBehavior {
     DespawnAfterAnimation,
-    FadeOutTimeMs(Timer),
+    FadeOutMs(Timer),
 }
 
 /// Execute behaviors specific to effects
+#[allow(clippy::complexity)]
 pub fn effect_execute_behavior_system(
     mut commands: Commands,
     mut effect_query: Query<(
@@ -34,9 +35,10 @@ pub fn effect_execute_behavior_system(
                         commands.entity(entity).despawn_recursive();
                     }
                 }
-                EffectBehavior::FadeOutTimeMs(timer) => {
+                EffectBehavior::FadeOutMs(timer) => {
                     timer.tick(time.delta());
                     if let Some(text) = text.as_mut().unwrap().sections.get_mut(0) {
+                        // set alpha color channel to the percent left in the timer
                         text.style.color.set_a(timer.percent_left());
                     }
                     if timer.just_finished() {

--- a/src/spawnable/effect/mod.rs
+++ b/src/spawnable/effect/mod.rs
@@ -65,8 +65,13 @@ pub fn spawn_effect_system(
     effect_assets: Res<EffectAssets>,
 ) {
     for event in event_reader.iter() {
-        if let EffectType::DamageNumber(num) = event.effect_type {
-            spawn_damage_number(num, event.transform, &mut commands, &asset_server);
+        if let EffectType::DamageText(damage_text) = &event.effect_type {
+            spawn_damage_text(
+                damage_text.to_string(),
+                event.transform,
+                &mut commands,
+                &asset_server,
+            );
         } else {
             spawn_effect(
                 &event.effect_type,
@@ -80,8 +85,8 @@ pub fn spawn_effect_system(
     }
 }
 
-fn spawn_damage_number(
-    damage_num: usize,
+fn spawn_damage_text(
+    damage_text: String,
     transform: Transform,
     commands: &mut Commands,
     asset_server: &AssetServer,
@@ -94,7 +99,8 @@ fn spawn_damage_number(
         .spawn(Text2dBundle {
             text: Text::from_section(
                 //damage_num.to_string(),
-                5.0.to_string(),
+                //5.0.to_string(),
+                damage_text.clone(),
                 TextStyle {
                     font: font.clone(),
                     font_size: 60.0,
@@ -116,7 +122,9 @@ fn spawn_damage_number(
                 }),
         )
         .insert(super::SpawnableComponent {
-            spawnable_type: super::SpawnableType::Effect(EffectType::DamageNumber(damage_num)),
+            spawnable_type: super::SpawnableType::Effect(EffectType::DamageText(
+                damage_text.clone(),
+            )),
             acceleration: Vec2::new(0.0, 0.0),
             deceleration: Vec2::new(0.0, 0.0),
             speed: Vec2::new(0.0, 0.0),
@@ -126,34 +134,13 @@ fn spawn_damage_number(
             behaviors: vec![],
         })
         .insert(EffectComponent {
-            effect_type: EffectType::DamageNumber(damage_num),
+            effect_type: EffectType::DamageText(damage_text),
             behaviors: vec![EffectBehavior::FadeOutTimeMs(Timer::from_seconds(
                 0.5,
                 TimerMode::Once,
             ))],
         })
-        .insert(GameCleanup)
-        .with_children(|parent| {
-            // spawn border text
-            parent
-                .spawn(Text2dBundle {
-                    text: Text::from_section(
-                        //damage_num.to_string(),
-                        5.0.to_string(),
-                        TextStyle {
-                            font,
-                            font_size: 60.0,
-                            color: Color::BLACK,
-                        },
-                    ),
-                    ..default()
-                })
-                .insert(Transform::from_scale(Vec3 {
-                    x: 1.15,
-                    y: 1.15,
-                    z: 0.0,
-                }));
-        });
+        .insert(GameCleanup);
 }
 
 /// Spawn effect from effect type

--- a/src/spawnable/effect/mod.rs
+++ b/src/spawnable/effect/mod.rs
@@ -7,8 +7,8 @@ use bevy::{prelude::*, sprite::Anchor};
 use bevy_rapier2d::prelude::*;
 use rand::Rng;
 use serde::Deserialize;
-use std::collections::HashMap;
-use thetawave_interface::spawnable::EffectType;
+use std::{collections::HashMap, ops::Range};
+use thetawave_interface::spawnable::{EffectType, TextEffectType};
 
 use super::InitialMotion;
 
@@ -38,11 +38,26 @@ pub struct EffectData {
     pub z_level: f32,
 }
 
+#[derive(Deserialize, Debug)]
+pub struct TextEffectData {
+    pub text: String,
+    pub text_color: Color,
+    pub font_size: f32,
+    pub translation_x: Range<f32>,
+    pub translation_y: Range<f32>,
+    pub scale: f32,
+}
+
 /// Resource to store data and textures of effects
 #[derive(Resource)]
 pub struct EffectsResource {
     /// Maps effect types to data
     pub effects: HashMap<EffectType, EffectData>,
+}
+
+#[derive(Resource)]
+pub struct TextEffectsResource {
+    pub text_effects: HashMap<TextEffectType, TextEffectData>,
 }
 
 /// Event for spawning effect
@@ -54,6 +69,8 @@ pub struct SpawnEffectEvent {
     pub transform: Transform,
     /// Initial motion of the effect
     pub initial_motion: InitialMotion,
+    /// Send optional text to be used in some effects
+    pub text: Option<String>,
 }
 
 /// Handles spawning of effects from events
@@ -62,16 +79,24 @@ pub fn spawn_effect_system(
     mut event_reader: EventReader<SpawnEffectEvent>,
     asset_server: Res<AssetServer>,
     effects_resource: Res<EffectsResource>,
+    text_effects_resource: Res<TextEffectsResource>,
     effect_assets: Res<EffectAssets>,
 ) {
     for event in event_reader.iter() {
-        if let EffectType::DamageText(damage_text) = &event.effect_type {
-            spawn_damage_text(
-                damage_text.to_string(),
-                event.transform,
-                &mut commands,
-                &asset_server,
-            );
+        if let EffectType::Text(text_effect_type) = &event.effect_type {
+            match text_effect_type {
+                TextEffectType::DamageDealt => {
+                    spawn_damage_text_effect(
+                        event.text.clone().unwrap(),
+                        event.transform,
+                        &mut commands,
+                        &asset_server,
+                        &text_effects_resource,
+                        &effects_resource,
+                    );
+                }
+                TextEffectType::ConsumableCollected(consumable_type) => todo!(),
+            }
         } else {
             spawn_effect(
                 &event.effect_type,
@@ -85,15 +110,22 @@ pub fn spawn_effect_system(
     }
 }
 
-fn spawn_damage_text(
+fn spawn_damage_text_effect(
     damage_text: String,
     transform: Transform,
     commands: &mut Commands,
     asset_server: &AssetServer,
+    text_effects_resource: &TextEffectsResource,
+    effects_resource: &EffectsResource,
 ) {
     let font = asset_server.load("fonts/wibletown-regular.otf");
 
     let mut rng = rand::thread_rng();
+
+    let effect_data = &effects_resource.effects[&EffectType::Text(TextEffectType::DamageDealt)];
+
+    // Get data from effect resource
+    let text_effect_data = &text_effects_resource.text_effects[&TextEffectType::DamageDealt];
 
     commands
         .spawn(Text2dBundle {
@@ -101,8 +133,8 @@ fn spawn_damage_text(
                 damage_text.clone(),
                 TextStyle {
                     font: font.clone(),
-                    font_size: 60.0,
-                    color: Color::WHITE,
+                    font_size: text_effect_data.font_size,
+                    color: text_effect_data.text_color,
                 },
             ),
             ..default()
@@ -111,17 +143,21 @@ fn spawn_damage_text(
             transform
                 .with_translation(
                     transform.translation
-                        + Vec3::new(rng.gen_range(-45.0..50.0), rng.gen_range(-45.0..45.0), 1.0),
+                        + Vec3::new(
+                            rng.gen_range(text_effect_data.translation_x.clone()),
+                            rng.gen_range(text_effect_data.translation_y.clone()),
+                            effect_data.z_level,
+                        ),
                 )
                 .with_scale(Vec3 {
-                    x: 0.4,
-                    y: 0.4,
+                    x: text_effect_data.scale,
+                    y: text_effect_data.scale,
                     z: 0.0,
                 }),
         )
         .insert(super::SpawnableComponent {
-            spawnable_type: super::SpawnableType::Effect(EffectType::DamageText(
-                damage_text.clone(),
+            spawnable_type: super::SpawnableType::Effect(EffectType::Text(
+                TextEffectType::DamageDealt,
             )),
             acceleration: Vec2::new(0.0, 0.0),
             deceleration: Vec2::new(0.0, 0.0),
@@ -132,11 +168,8 @@ fn spawn_damage_text(
             behaviors: vec![],
         })
         .insert(EffectComponent {
-            effect_type: EffectType::DamageText(damage_text),
-            behaviors: vec![EffectBehavior::FadeOutMs(Timer::from_seconds(
-                0.55,
-                TimerMode::Once,
-            ))],
+            effect_type: EffectType::Text(TextEffectType::DamageDealt),
+            behaviors: effect_data.effect_behaviors.clone(),
         })
         .insert(GameCleanup);
 }
@@ -161,7 +194,7 @@ pub fn spawn_effect(
 
     effect
         .insert(SpriteSheetBundle {
-            texture_atlas: effect_assets.get_asset(effect_type),
+            texture_atlas: effect_assets.get_asset(effect_type).unwrap(),
             ..Default::default()
         })
         .insert(AnimationComponent {

--- a/src/spawnable/effect/mod.rs
+++ b/src/spawnable/effect/mod.rs
@@ -98,8 +98,6 @@ fn spawn_damage_text(
     commands
         .spawn(Text2dBundle {
             text: Text::from_section(
-                //damage_num.to_string(),
-                //5.0.to_string(),
                 damage_text.clone(),
                 TextStyle {
                     font: font.clone(),
@@ -113,7 +111,7 @@ fn spawn_damage_text(
             transform
                 .with_translation(
                     transform.translation
-                        + Vec3::new(rng.gen_range(-50.0..50.0), rng.gen_range(-50.0..50.0), 0.0),
+                        + Vec3::new(rng.gen_range(-50.0..50.0), rng.gen_range(-50.0..50.0), 1.0),
                 )
                 .with_scale(Vec3 {
                     x: 0.6,
@@ -135,7 +133,7 @@ fn spawn_damage_text(
         })
         .insert(EffectComponent {
             effect_type: EffectType::DamageText(damage_text),
-            behaviors: vec![EffectBehavior::FadeOutTimeMs(Timer::from_seconds(
+            behaviors: vec![EffectBehavior::FadeOutMs(Timer::from_seconds(
                 0.5,
                 TimerMode::Once,
             ))],

--- a/src/spawnable/effect/mod.rs
+++ b/src/spawnable/effect/mod.rs
@@ -60,7 +60,7 @@ pub struct TextEffectsResource {
 }
 
 /// Event for spawning effect
-#[derive(Event)]
+#[derive(Event, Default)]
 pub struct SpawnEffectEvent {
     /// Type of the effect
     pub effect_type: EffectType,
@@ -187,7 +187,7 @@ pub fn spawn_effect(
 
     effect
         .insert(SpriteSheetBundle {
-            texture_atlas: effect_assets.get_asset(effect_type).unwrap(),
+            texture_atlas: effect_assets.get_asset(effect_type).unwrap_or_default(),
             ..Default::default()
         })
         .insert(AnimationComponent {

--- a/src/spawnable/effect/mod.rs
+++ b/src/spawnable/effect/mod.rs
@@ -39,11 +39,17 @@ pub struct EffectData {
 
 #[derive(Deserialize, Debug)]
 pub struct TextEffectData {
+    /// Text of the effect
     pub text: String,
+    /// Color of the text
     pub text_color: Color,
+    /// Font size pf the text
     pub font_size: f32,
+    /// X position range (randomly chosen)
     pub translation_x: Range<f32>,
+    /// Y position range (randomly chosen)
     pub translation_y: Range<f32>,
+    /// Scale of the text
     pub scale: f32,
 }
 
@@ -56,6 +62,7 @@ pub struct EffectsResource {
 
 #[derive(Resource)]
 pub struct TextEffectsResource {
+    /// Maps text effect types to data
     pub text_effects: HashMap<TextEffectType, TextEffectData>,
 }
 
@@ -167,7 +174,7 @@ fn spawn_text_effect(
         .insert(GameCleanup);
 }
 
-/// Spawn effect from effect type
+/// Spawn a non-text effect from effect type
 pub fn spawn_effect(
     effect_type: &EffectType,
     effects_resource: &EffectsResource,

--- a/src/spawnable/effect/mod.rs
+++ b/src/spawnable/effect/mod.rs
@@ -3,7 +3,7 @@ use crate::{
     assets::EffectAssets,
     states::GameCleanup,
 };
-use bevy::prelude::*;
+use bevy::{prelude::*, sprite::Anchor};
 use bevy_rapier2d::prelude::*;
 use rand::Rng;
 use serde::Deserialize;
@@ -111,11 +111,11 @@ fn spawn_damage_text(
             transform
                 .with_translation(
                     transform.translation
-                        + Vec3::new(rng.gen_range(-50.0..50.0), rng.gen_range(-50.0..50.0), 1.0),
+                        + Vec3::new(rng.gen_range(-45.0..50.0), rng.gen_range(-45.0..45.0), 1.0),
                 )
                 .with_scale(Vec3 {
-                    x: 0.6,
-                    y: 0.6,
+                    x: 0.4,
+                    y: 0.4,
                     z: 0.0,
                 }),
         )
@@ -134,7 +134,7 @@ fn spawn_damage_text(
         .insert(EffectComponent {
             effect_type: EffectType::DamageText(damage_text),
             behaviors: vec![EffectBehavior::FadeOutMs(Timer::from_seconds(
-                0.5,
+                0.55,
                 TimerMode::Once,
             ))],
         })

--- a/src/spawnable/mob/behavior.rs
+++ b/src/spawnable/mob/behavior.rs
@@ -3,7 +3,7 @@ use bevy::prelude::*;
 use bevy_kira_audio::prelude::*;
 use bevy_rapier2d::prelude::*;
 use serde::Deserialize;
-use thetawave_interface::spawnable::{EffectType, MobType, ProjectileType};
+use thetawave_interface::spawnable::{EffectType, MobType, ProjectileType, TextEffectType};
 
 use crate::{
     assets::GameAudioAssets,
@@ -220,6 +220,7 @@ pub fn mob_execute_behavior_system(
                                 ..Default::default()
                             },
                             initial_motion: InitialMotion::default(),
+                            text: None,
                         });
 
                         // drop loot
@@ -273,13 +274,14 @@ fn receive_damage_on_impact(
                         if player_entity_q == *player_entity && *player_damage > 0.0 {
                             mob_component.health.take_damage(*player_damage);
                             spawn_effect_event_writer.send(SpawnEffectEvent {
-                                effect_type: EffectType::DamageText(player_damage.to_string()),
+                                effect_type: EffectType::Text(TextEffectType::DamageDealt),
                                 transform: Transform {
                                     translation: mob_transform.translation,
                                     scale: mob_transform.scale,
                                     ..Default::default()
                                 },
                                 initial_motion: InitialMotion::default(),
+                                text: Some(player_damage.to_string()),
                             });
                         }
                     }
@@ -296,13 +298,14 @@ fn receive_damage_on_impact(
                 if entity == *mob_entity_1 && *mob_damage_2 > 0.0 {
                     mob_component.health.take_damage(*mob_damage_2);
                     spawn_effect_event_writer.send(SpawnEffectEvent {
-                        effect_type: EffectType::DamageText(mob_damage_2.to_string()),
+                        effect_type: EffectType::Text(TextEffectType::DamageDealt),
                         transform: Transform {
                             translation: mob_transform.translation,
                             scale: mob_transform.scale,
                             ..Default::default()
                         },
                         initial_motion: InitialMotion::default(),
+                        text: Some(mob_damage_2.to_string()),
                     });
                 }
             }
@@ -317,13 +320,14 @@ fn receive_damage_on_impact(
                 if entity == *mob_entity && *mob_segment_damage > 0.0 {
                     mob_component.health.take_damage(*mob_segment_damage);
                     spawn_effect_event_writer.send(SpawnEffectEvent {
-                        effect_type: EffectType::DamageText(mob_segment_damage.to_string()),
+                        effect_type: EffectType::Text(TextEffectType::DamageDealt),
                         transform: Transform {
                             translation: mob_transform.translation,
                             scale: mob_transform.scale,
                             ..Default::default()
                         },
                         initial_motion: InitialMotion::default(),
+                        text: Some(mob_segment_damage.to_string()),
                     });
                 }
             }
@@ -400,6 +404,7 @@ fn explode_on_impact(
                             ..Default::default()
                         },
                         initial_motion: InitialMotion::default(),
+                        text: None,
                     });
                     // despawn mob
                     commands.entity(entity).despawn_recursive();
@@ -429,6 +434,7 @@ fn explode_on_impact(
                             ..Default::default()
                         },
                         initial_motion: InitialMotion::default(),
+                        text: None,
                     });
                     // despawn mob
                     commands.entity(entity).despawn_recursive();
@@ -457,6 +463,7 @@ fn explode_on_impact(
                             ..Default::default()
                         },
                         initial_motion: InitialMotion::default(),
+                        text: None,
                     });
                     commands.entity(entity).despawn_recursive();
                     continue;

--- a/src/spawnable/mob/behavior.rs
+++ b/src/spawnable/mob/behavior.rs
@@ -219,8 +219,7 @@ pub fn mob_execute_behavior_system(
                                 ),
                                 ..Default::default()
                             },
-                            initial_motion: InitialMotion::default(),
-                            text: None,
+                            ..default()
                         });
 
                         // drop loot
@@ -280,8 +279,8 @@ fn receive_damage_on_impact(
                                     scale: mob_transform.scale,
                                     ..Default::default()
                                 },
-                                initial_motion: InitialMotion::default(),
                                 text: Some(player_damage.to_string()),
+                                ..default()
                             });
                         }
                     }
@@ -304,8 +303,8 @@ fn receive_damage_on_impact(
                             scale: mob_transform.scale,
                             ..Default::default()
                         },
-                        initial_motion: InitialMotion::default(),
                         text: Some(mob_damage_2.to_string()),
+                        ..default()
                     });
                 }
             }
@@ -326,8 +325,8 @@ fn receive_damage_on_impact(
                             scale: mob_transform.scale,
                             ..Default::default()
                         },
-                        initial_motion: InitialMotion::default(),
                         text: Some(mob_segment_damage.to_string()),
+                        ..default()
                     });
                 }
             }
@@ -403,8 +402,7 @@ fn explode_on_impact(
                             ),
                             ..Default::default()
                         },
-                        initial_motion: InitialMotion::default(),
-                        text: None,
+                        ..default()
                     });
                     // despawn mob
                     commands.entity(entity).despawn_recursive();
@@ -433,8 +431,7 @@ fn explode_on_impact(
                             ),
                             ..Default::default()
                         },
-                        initial_motion: InitialMotion::default(),
-                        text: None,
+                        ..default()
                     });
                     // despawn mob
                     commands.entity(entity).despawn_recursive();
@@ -462,8 +459,7 @@ fn explode_on_impact(
                             ),
                             ..Default::default()
                         },
-                        initial_motion: InitialMotion::default(),
-                        text: None,
+                        ..default()
                     });
                     commands.entity(entity).despawn_recursive();
                     continue;

--- a/src/spawnable/mob/behavior.rs
+++ b/src/spawnable/mob/behavior.rs
@@ -272,6 +272,8 @@ fn receive_damage_on_impact(
                     for (player_entity_q, mut _player_component) in player_query.iter_mut() {
                         if player_entity_q == *player_entity && *player_damage > 0.0 {
                             mob_component.health.take_damage(*player_damage);
+
+                            // spawn damage dealt text effect
                             spawn_effect_event_writer.send(SpawnEffectEvent {
                                 effect_type: EffectType::Text(TextEffectType::DamageDealt),
                                 transform: Transform {
@@ -296,6 +298,8 @@ fn receive_damage_on_impact(
             } => {
                 if entity == *mob_entity_1 && *mob_damage_2 > 0.0 {
                     mob_component.health.take_damage(*mob_damage_2);
+
+                    // spawn damage dealt text effect
                     spawn_effect_event_writer.send(SpawnEffectEvent {
                         effect_type: EffectType::Text(TextEffectType::DamageDealt),
                         transform: Transform {
@@ -318,6 +322,8 @@ fn receive_damage_on_impact(
             } => {
                 if entity == *mob_entity && *mob_segment_damage > 0.0 {
                     mob_component.health.take_damage(*mob_segment_damage);
+
+                    // spawn damage dealt text effect
                     spawn_effect_event_writer.send(SpawnEffectEvent {
                         effect_type: EffectType::Text(TextEffectType::DamageDealt),
                         transform: Transform {

--- a/src/spawnable/mob/behavior.rs
+++ b/src/spawnable/mob/behavior.rs
@@ -198,6 +198,8 @@ pub fn mob_execute_behavior_system(
                         entity,
                         &collision_events_vec,
                         &mut mob_component,
+                        *mob_transform,
+                        &mut spawn_effect_event_writer,
                         &mut player_query,
                     );
                 }
@@ -253,6 +255,8 @@ fn receive_damage_on_impact(
     entity: Entity,
     collision_events: &[&SortedCollisionEvent],
     mob_component: &mut super::MobComponent,
+    mob_transform: Transform,
+    spawn_effect_event_writer: &mut EventWriter<SpawnEffectEvent>,
     player_query: &mut Query<(Entity, &mut PlayerComponent)>,
 ) {
     for collision_event in collision_events.iter() {
@@ -268,6 +272,15 @@ fn receive_damage_on_impact(
                     for (player_entity_q, mut _player_component) in player_query.iter_mut() {
                         if player_entity_q == *player_entity {
                             mob_component.health.take_damage(*player_damage);
+                            spawn_effect_event_writer.send(SpawnEffectEvent {
+                                effect_type: EffectType::DamageText(player_damage.to_string()),
+                                transform: Transform {
+                                    translation: mob_transform.translation,
+                                    scale: mob_transform.scale,
+                                    ..Default::default()
+                                },
+                                initial_motion: InitialMotion::default(),
+                            });
                         }
                     }
                 }
@@ -282,6 +295,15 @@ fn receive_damage_on_impact(
             } => {
                 if entity == *mob_entity_1 {
                     mob_component.health.take_damage(*mob_damage_2);
+                    spawn_effect_event_writer.send(SpawnEffectEvent {
+                        effect_type: EffectType::DamageText(mob_damage_2.to_string()),
+                        transform: Transform {
+                            translation: mob_transform.translation,
+                            scale: mob_transform.scale,
+                            ..Default::default()
+                        },
+                        initial_motion: InitialMotion::default(),
+                    });
                 }
             }
             SortedCollisionEvent::MobToMobSegmentContact {
@@ -294,6 +316,15 @@ fn receive_damage_on_impact(
             } => {
                 if entity == *mob_entity {
                     mob_component.health.take_damage(*mob_segment_damage);
+                    spawn_effect_event_writer.send(SpawnEffectEvent {
+                        effect_type: EffectType::DamageText(mob_segment_damage.to_string()),
+                        transform: Transform {
+                            translation: mob_transform.translation,
+                            scale: mob_transform.scale,
+                            ..Default::default()
+                        },
+                        initial_motion: InitialMotion::default(),
+                    });
                 }
             }
 

--- a/src/spawnable/mob/behavior.rs
+++ b/src/spawnable/mob/behavior.rs
@@ -270,7 +270,7 @@ fn receive_damage_on_impact(
             } => {
                 if entity == *mob_entity {
                     for (player_entity_q, mut _player_component) in player_query.iter_mut() {
-                        if player_entity_q == *player_entity {
+                        if player_entity_q == *player_entity && *player_damage > 0.0 {
                             mob_component.health.take_damage(*player_damage);
                             spawn_effect_event_writer.send(SpawnEffectEvent {
                                 effect_type: EffectType::DamageText(player_damage.to_string()),
@@ -293,7 +293,7 @@ fn receive_damage_on_impact(
                 mob_faction_2: _,
                 mob_damage_2,
             } => {
-                if entity == *mob_entity_1 {
+                if entity == *mob_entity_1 && *mob_damage_2 > 0.0 {
                     mob_component.health.take_damage(*mob_damage_2);
                     spawn_effect_event_writer.send(SpawnEffectEvent {
                         effect_type: EffectType::DamageText(mob_damage_2.to_string()),
@@ -314,7 +314,7 @@ fn receive_damage_on_impact(
                 mob_segment_faction: _,
                 mob_segment_damage,
             } => {
-                if entity == *mob_entity {
+                if entity == *mob_entity && *mob_segment_damage > 0.0 {
                     mob_component.health.take_damage(*mob_segment_damage);
                     spawn_effect_event_writer.send(SpawnEffectEvent {
                         effect_type: EffectType::DamageText(mob_segment_damage.to_string()),

--- a/src/spawnable/mob/behavior.rs
+++ b/src/spawnable/mob/behavior.rs
@@ -3,7 +3,10 @@ use bevy::prelude::*;
 use bevy_kira_audio::prelude::*;
 use bevy_rapier2d::prelude::*;
 use serde::Deserialize;
-use thetawave_interface::spawnable::{EffectType, MobType, ProjectileType, TextEffectType};
+use thetawave_interface::{
+    health::DamageDealtEvent,
+    spawnable::{EffectType, MobType, ProjectileType},
+};
 
 use crate::{
     assets::GameAudioAssets,
@@ -11,7 +14,6 @@ use crate::{
     collision::SortedCollisionEvent,
     game::GameParametersResource,
     loot::LootDropsResource,
-    misc::DamageDealtEvent,
     spawnable::{
         InitialMotion, PlayerComponent, SpawnConsumableEvent, SpawnEffectEvent,
         SpawnProjectileEvent,

--- a/src/spawnable/mob/mob_segment/behavior.rs
+++ b/src/spawnable/mob/mob_segment/behavior.rs
@@ -329,7 +329,7 @@ fn receive_damage_on_impact(
             } => {
                 if entity == *mob_segment_entity {
                     for (player_entity_q, mut _player_component) in player_query.iter_mut() {
-                        if player_entity_q == *player_entity {
+                        if player_entity_q == *player_entity && *player_damage > 0.0 {
                             mob_segment_component.health.take_damage(*player_damage);
                             spawn_effect_event_writer.send(SpawnEffectEvent {
                                 effect_type: EffectType::DamageText(player_damage.to_string()),
@@ -352,7 +352,7 @@ fn receive_damage_on_impact(
                 mob_faction: _,
                 mob_damage,
             } => {
-                if entity == *mob_segment_entity {
+                if entity == *mob_segment_entity && *mob_damage > 0.0 {
                     mob_segment_component.health.take_damage(*mob_damage);
                     spawn_effect_event_writer.send(SpawnEffectEvent {
                         effect_type: EffectType::DamageText(mob_damage.to_string()),
@@ -373,7 +373,7 @@ fn receive_damage_on_impact(
                 mob_segment_faction_2: _,
                 mob_segment_damage_2,
             } => {
-                if entity == *mob_segment_entity_1 {
+                if entity == *mob_segment_entity_1 && *mob_segment_damage_2 > 0.0 {
                     mob_segment_component
                         .health
                         .take_damage(*mob_segment_damage_2);

--- a/src/spawnable/mob/mob_segment/behavior.rs
+++ b/src/spawnable/mob/mob_segment/behavior.rs
@@ -100,6 +100,8 @@ pub fn mob_segment_execute_behavior_system(
                         entity,
                         &collision_events_vec,
                         &mut mob_segment_component,
+                        *mob_segment_transform,
+                        &mut spawn_effect_event_writer,
                         &mut player_query,
                     );
                 }
@@ -312,6 +314,8 @@ fn receive_damage_on_impact(
     entity: Entity,
     collision_events: &[&SortedCollisionEvent],
     mob_segment_component: &mut super::MobSegmentComponent,
+    mob_segment_transform: Transform,
+    spawn_effect_event_writer: &mut EventWriter<SpawnEffectEvent>,
     player_query: &mut Query<(Entity, &mut PlayerComponent)>,
 ) {
     for collision_event in collision_events.iter() {
@@ -327,6 +331,15 @@ fn receive_damage_on_impact(
                     for (player_entity_q, mut _player_component) in player_query.iter_mut() {
                         if player_entity_q == *player_entity {
                             mob_segment_component.health.take_damage(*player_damage);
+                            spawn_effect_event_writer.send(SpawnEffectEvent {
+                                effect_type: EffectType::DamageText(player_damage.to_string()),
+                                transform: Transform {
+                                    translation: mob_segment_transform.translation,
+                                    scale: mob_segment_transform.scale,
+                                    ..Default::default()
+                                },
+                                initial_motion: InitialMotion::default(),
+                            });
                         }
                     }
                 }
@@ -341,6 +354,15 @@ fn receive_damage_on_impact(
             } => {
                 if entity == *mob_segment_entity {
                     mob_segment_component.health.take_damage(*mob_damage);
+                    spawn_effect_event_writer.send(SpawnEffectEvent {
+                        effect_type: EffectType::DamageText(mob_damage.to_string()),
+                        transform: Transform {
+                            translation: mob_segment_transform.translation,
+                            scale: mob_segment_transform.scale,
+                            ..Default::default()
+                        },
+                        initial_motion: InitialMotion::default(),
+                    });
                 }
             }
             SortedCollisionEvent::MobSegmentToMobSegmentContact {
@@ -355,6 +377,15 @@ fn receive_damage_on_impact(
                     mob_segment_component
                         .health
                         .take_damage(*mob_segment_damage_2);
+                    spawn_effect_event_writer.send(SpawnEffectEvent {
+                        effect_type: EffectType::DamageText(mob_segment_damage_2.to_string()),
+                        transform: Transform {
+                            translation: mob_segment_transform.translation,
+                            scale: mob_segment_transform.scale,
+                            ..Default::default()
+                        },
+                        initial_motion: InitialMotion::default(),
+                    });
                 }
             }
 

--- a/src/spawnable/mob/mob_segment/behavior.rs
+++ b/src/spawnable/mob/mob_segment/behavior.rs
@@ -121,8 +121,7 @@ pub fn mob_segment_execute_behavior_system(
                                 ),
                                 ..Default::default()
                             },
-                            initial_motion: InitialMotion::default(),
-                            text: None,
+                            ..default()
                         });
 
                         // drop loot
@@ -339,8 +338,8 @@ fn receive_damage_on_impact(
                                     scale: mob_segment_transform.scale,
                                     ..Default::default()
                                 },
-                                initial_motion: InitialMotion::default(),
                                 text: Some(player_damage.to_string()),
+                                ..default()
                             });
                         }
                     }
@@ -363,8 +362,8 @@ fn receive_damage_on_impact(
                             scale: mob_segment_transform.scale,
                             ..Default::default()
                         },
-                        initial_motion: InitialMotion::default(),
                         text: Some(mob_damage.to_string()),
+                        ..default()
                     });
                 }
             }
@@ -387,8 +386,8 @@ fn receive_damage_on_impact(
                             scale: mob_segment_transform.scale,
                             ..Default::default()
                         },
-                        initial_motion: InitialMotion::default(),
                         text: Some(mob_segment_damage_2.to_string()),
+                        ..default()
                     });
                 }
             }

--- a/src/spawnable/mob/mob_segment/behavior.rs
+++ b/src/spawnable/mob/mob_segment/behavior.rs
@@ -4,7 +4,7 @@ use bevy_kira_audio::{AudioChannel, AudioControl};
 use bevy_rapier2d::{prelude::*, rapier::prelude::JointAxis};
 use rand::{thread_rng, Rng};
 use serde::Deserialize;
-use thetawave_interface::spawnable::{EffectType, TextEffectType};
+use thetawave_interface::{health::DamageDealtEvent, spawnable::EffectType};
 
 use crate::{
     assets::GameAudioAssets,
@@ -12,7 +12,6 @@ use crate::{
     collision::SortedCollisionEvent,
     game::GameParametersResource,
     loot::LootDropsResource,
-    misc::DamageDealtEvent,
     player::PlayerComponent,
     spawnable::{
         behavior_sequence::EntityPair, mob, InitialMotion, MobDestroyedEvent, SpawnConsumableEvent,

--- a/src/spawnable/mob/mob_segment/behavior.rs
+++ b/src/spawnable/mob/mob_segment/behavior.rs
@@ -331,6 +331,8 @@ fn receive_damage_on_impact(
                     for (player_entity_q, mut _player_component) in player_query.iter_mut() {
                         if player_entity_q == *player_entity && *player_damage > 0.0 {
                             mob_segment_component.health.take_damage(*player_damage);
+
+                            // spawn damage dealt text effect
                             spawn_effect_event_writer.send(SpawnEffectEvent {
                                 effect_type: EffectType::Text(TextEffectType::DamageDealt),
                                 transform: Transform {
@@ -355,6 +357,8 @@ fn receive_damage_on_impact(
             } => {
                 if entity == *mob_segment_entity && *mob_damage > 0.0 {
                     mob_segment_component.health.take_damage(*mob_damage);
+
+                    // spawn damage dealt text effect
                     spawn_effect_event_writer.send(SpawnEffectEvent {
                         effect_type: EffectType::Text(TextEffectType::DamageDealt),
                         transform: Transform {
@@ -379,6 +383,8 @@ fn receive_damage_on_impact(
                     mob_segment_component
                         .health
                         .take_damage(*mob_segment_damage_2);
+
+                    // spawn damage dealt text effect
                     spawn_effect_event_writer.send(SpawnEffectEvent {
                         effect_type: EffectType::Text(TextEffectType::DamageDealt),
                         transform: Transform {

--- a/src/spawnable/mob/mob_segment/behavior.rs
+++ b/src/spawnable/mob/mob_segment/behavior.rs
@@ -4,7 +4,7 @@ use bevy_kira_audio::{AudioChannel, AudioControl};
 use bevy_rapier2d::{prelude::*, rapier::prelude::JointAxis};
 use rand::{thread_rng, Rng};
 use serde::Deserialize;
-use thetawave_interface::spawnable::EffectType;
+use thetawave_interface::spawnable::{EffectType, TextEffectType};
 
 use crate::{
     assets::GameAudioAssets,
@@ -122,6 +122,7 @@ pub fn mob_segment_execute_behavior_system(
                                 ..Default::default()
                             },
                             initial_motion: InitialMotion::default(),
+                            text: None,
                         });
 
                         // drop loot
@@ -332,13 +333,14 @@ fn receive_damage_on_impact(
                         if player_entity_q == *player_entity && *player_damage > 0.0 {
                             mob_segment_component.health.take_damage(*player_damage);
                             spawn_effect_event_writer.send(SpawnEffectEvent {
-                                effect_type: EffectType::DamageText(player_damage.to_string()),
+                                effect_type: EffectType::Text(TextEffectType::DamageDealt),
                                 transform: Transform {
                                     translation: mob_segment_transform.translation,
                                     scale: mob_segment_transform.scale,
                                     ..Default::default()
                                 },
                                 initial_motion: InitialMotion::default(),
+                                text: Some(player_damage.to_string()),
                             });
                         }
                     }
@@ -355,13 +357,14 @@ fn receive_damage_on_impact(
                 if entity == *mob_segment_entity && *mob_damage > 0.0 {
                     mob_segment_component.health.take_damage(*mob_damage);
                     spawn_effect_event_writer.send(SpawnEffectEvent {
-                        effect_type: EffectType::DamageText(mob_damage.to_string()),
+                        effect_type: EffectType::Text(TextEffectType::DamageDealt),
                         transform: Transform {
                             translation: mob_segment_transform.translation,
                             scale: mob_segment_transform.scale,
                             ..Default::default()
                         },
                         initial_motion: InitialMotion::default(),
+                        text: Some(mob_damage.to_string()),
                     });
                 }
             }
@@ -378,13 +381,14 @@ fn receive_damage_on_impact(
                         .health
                         .take_damage(*mob_segment_damage_2);
                     spawn_effect_event_writer.send(SpawnEffectEvent {
-                        effect_type: EffectType::DamageText(mob_segment_damage_2.to_string()),
+                        effect_type: EffectType::Text(TextEffectType::DamageDealt),
                         transform: Transform {
                             translation: mob_segment_transform.translation,
                             scale: mob_segment_transform.scale,
                             ..Default::default()
                         },
                         initial_motion: InitialMotion::default(),
+                        text: Some(mob_segment_damage_2.to_string()),
                     });
                 }
             }

--- a/src/spawnable/mod.rs
+++ b/src/spawnable/mod.rs
@@ -126,7 +126,7 @@ impl Plugin for SpawnablePlugin {
 }
 
 /// Core component of spawnable entities
-#[derive(Component)]
+#[derive(Component, Default)]
 pub struct SpawnableComponent {
     /// Type of spawnable
     pub spawnable_type: SpawnableType,

--- a/src/spawnable/mod.rs
+++ b/src/spawnable/mod.rs
@@ -7,6 +7,7 @@ use bevy_rapier2d::prelude::Velocity;
 use rand::{thread_rng, Rng};
 use ron::de::from_bytes;
 use serde::Deserialize;
+use thetawave_interface::spawnable::TextEffectType;
 pub use thetawave_interface::spawnable::{
     ConsumableType, EffectType, MobType, ProjectileType, SpawnableType,
 };
@@ -18,6 +19,7 @@ mod effect;
 mod mob;
 mod projectile;
 
+use self::effect::{TextEffectData, TextEffectsResource};
 pub use self::mob::*;
 pub use self::projectile::{
     projectile_execute_behavior_system, spawn_projectile_system, ProjectileComponent,
@@ -67,6 +69,12 @@ impl Plugin for SpawnablePlugin {
         .insert_resource(EffectsResource {
             effects: from_bytes::<HashMap<EffectType, EffectData>>(include_bytes!(
                 "../../assets/data/effects.ron"
+            ))
+            .unwrap(),
+        })
+        .insert_resource(TextEffectsResource {
+            text_effects: from_bytes::<HashMap<TextEffectType, TextEffectData>>(include_bytes!(
+                "../../assets/data/text_effects.ron"
             ))
             .unwrap(),
         })

--- a/src/spawnable/mod.rs
+++ b/src/spawnable/mod.rs
@@ -53,42 +53,42 @@ impl Plugin for SpawnablePlugin {
             from_bytes::<BehaviorSequenceResource>(include_bytes!(
                 "../../assets/data/behavior_sequences.ron"
             ))
-            .unwrap(),
+            .expect("Failed to parse BehaviorSequenceResource from 'behavior_sequences.ron'"),
         )
         .insert_resource(MobsResource {
             mobs: from_bytes::<HashMap<MobType, MobData>>(include_bytes!(
                 "../../assets/data/mobs.ron"
             ))
-            .unwrap(),
+            .expect("Failed to parse MobsResource from 'mobs.ron'"),
             texture_atlas_handle: HashMap::new(),
         })
         .insert_resource(
             from_bytes::<MobSegmentsResource>(include_bytes!("../../assets/data/mob_segments.ron"))
-                .unwrap(),
+                .expect("Failed to parse MobSegmentsResource from 'mob_segments.ron'"),
         )
         .insert_resource(EffectsResource {
             effects: from_bytes::<HashMap<EffectType, EffectData>>(include_bytes!(
                 "../../assets/data/effects.ron"
             ))
-            .unwrap(),
+            .expect("Failed to parse EffectsResource from 'effects.ron'"),
         })
         .insert_resource(TextEffectsResource {
             text_effects: from_bytes::<HashMap<TextEffectType, TextEffectData>>(include_bytes!(
                 "../../assets/data/text_effects.ron"
             ))
-            .unwrap(),
+            .expect("Failed to parse TextEffectsResource from 'text_effects.ron'"),
         })
         .insert_resource(ProjectileResource {
             projectiles: from_bytes::<HashMap<ProjectileType, ProjectileData>>(include_bytes!(
                 "../../assets/data/projectiles.ron"
             ))
-            .unwrap(),
+            .expect("Failed to parse ProjectileResource from 'projectiles.ron'"),
         })
         .insert_resource(ConsumableResource {
             consumables: from_bytes::<HashMap<ConsumableType, ConsumableData>>(include_bytes!(
                 "../../assets/data/consumables.ron"
             ))
-            .unwrap(),
+            .expect("Failed to parse ConsumableResource from 'consumables.ron'"),
         });
 
         app.add_event::<SpawnEffectEvent>()

--- a/src/spawnable/projectile/behavior.rs
+++ b/src/spawnable/projectile/behavior.rs
@@ -101,8 +101,7 @@ pub fn projectile_execute_behavior_system(
                                             scale: projectile_transform.scale,
                                             ..Default::default()
                                         },
-                                        initial_motion: InitialMotion::default(),
-                                        text: None,
+                                        ..default()
                                     });
                                 }
                                 Faction::Ally => {
@@ -113,8 +112,7 @@ pub fn projectile_execute_behavior_system(
                                             scale: projectile_transform.scale,
                                             ..Default::default()
                                         },
-                                        initial_motion: InitialMotion::default(),
-                                        text: None,
+                                        ..default()
                                     });
                                 }
                                 _ => {}
@@ -128,8 +126,7 @@ pub fn projectile_execute_behavior_system(
                                             scale: projectile_transform.scale,
                                             ..Default::default()
                                         },
-                                        initial_motion: InitialMotion::default(),
-                                        text: None,
+                                        ..default()
                                     });
                                 }
 
@@ -141,8 +138,7 @@ pub fn projectile_execute_behavior_system(
                                             scale: projectile_transform.scale,
                                             ..Default::default()
                                         },
-                                        initial_motion: InitialMotion::default(),
-                                        text: None,
+                                        ..default()
                                     });
                                 }
                                 _ => {}
@@ -221,8 +217,8 @@ fn deal_damage_on_contact(
                                     scale: mob_transform.scale,
                                     ..Default::default()
                                 },
-                                initial_motion: InitialMotion::default(),
                                 text: Some(projectile_damage.to_string()),
+                                ..default()
                             });
                         }
                     }
@@ -258,8 +254,8 @@ fn deal_damage_on_contact(
                                     scale: mob_segment_transform.scale,
                                     ..Default::default()
                                 },
-                                initial_motion: InitialMotion::default(),
                                 text: Some(projectile_damage.to_string()),
+                                ..default()
                             });
                         }
                     }
@@ -335,8 +331,8 @@ fn deal_damage_on_intersection(
                                     scale: mob_transform.scale,
                                     ..Default::default()
                                 },
-                                initial_motion: InitialMotion::default(),
                                 text: Some(projectile_damage.to_string()),
+                                ..default()
                             });
                         }
                     }
@@ -371,8 +367,8 @@ fn deal_damage_on_intersection(
                                     scale: mob_segment_transform.scale,
                                     ..Default::default()
                                 },
-                                initial_motion: InitialMotion::default(),
                                 text: Some(projectile_damage.to_string()),
+                                ..default()
                             });
                         }
                     }
@@ -417,8 +413,7 @@ fn explode_on_intersection(
                             scale: transform.scale,
                             ..Default::default()
                         },
-                        initial_motion: InitialMotion::default(),
-                        text: None,
+                        ..default()
                     });
 
                     // despawn blast
@@ -454,8 +449,7 @@ fn explode_on_intersection(
                                     scale: transform.scale,
                                     ..Default::default()
                                 },
-                                initial_motion: InitialMotion::default(),
-                                text: None,
+                                ..default()
                             });
                         }
                         Faction::Enemy => {
@@ -467,8 +461,7 @@ fn explode_on_intersection(
                                     scale: transform.scale,
                                     ..Default::default()
                                 },
-                                initial_motion: InitialMotion::default(),
-                                text: None,
+                                ..default()
                             });
                         }
                         Faction::Neutral => {}
@@ -504,8 +497,7 @@ fn explode_on_intersection(
                                     scale: transform.scale,
                                     ..Default::default()
                                 },
-                                initial_motion: InitialMotion::default(),
-                                text: None,
+                                ..default()
                             });
                         }
                         Faction::Enemy => {
@@ -517,8 +509,7 @@ fn explode_on_intersection(
                                     scale: transform.scale,
                                     ..Default::default()
                                 },
-                                initial_motion: InitialMotion::default(),
-                                text: None,
+                                ..default()
                             });
                         }
                         Faction::Neutral => {}
@@ -567,8 +558,7 @@ fn explode_on_contact(
                             scale: transform.scale,
                             ..Default::default()
                         },
-                        initial_motion: InitialMotion::default(),
-                        text: None,
+                        ..default()
                     });
 
                     // despawn blast
@@ -598,8 +588,7 @@ fn explode_on_contact(
                                     scale: transform.scale,
                                     ..Default::default()
                                 },
-                                initial_motion: InitialMotion::default(),
-                                text: None,
+                                ..default()
                             });
                         }
                         Faction::Enemy => {
@@ -611,8 +600,7 @@ fn explode_on_contact(
                                     scale: transform.scale,
                                     ..Default::default()
                                 },
-                                initial_motion: InitialMotion::default(),
-                                text: None,
+                                ..default()
                             });
                         }
                         Faction::Neutral => {}
@@ -643,8 +631,7 @@ fn explode_on_contact(
                                     scale: transform.scale,
                                     ..Default::default()
                                 },
-                                initial_motion: InitialMotion::default(),
-                                text: None,
+                                ..default()
                             });
                         }
                         Faction::Enemy => {
@@ -656,8 +643,7 @@ fn explode_on_contact(
                                     scale: transform.scale,
                                     ..Default::default()
                                 },
-                                initial_motion: InitialMotion::default(),
-                                text: None,
+                                ..default()
                             });
                         }
                         Faction::Neutral => {}
@@ -687,8 +673,7 @@ fn explode_on_contact(
                                     scale: transform.scale,
                                     ..Default::default()
                                 },
-                                initial_motion: InitialMotion::default(),
-                                text: None,
+                                ..default()
                             });
                         }
                         Faction::Enemy => {
@@ -700,8 +685,7 @@ fn explode_on_contact(
                                     scale: transform.scale,
                                     ..Default::default()
                                 },
-                                initial_motion: InitialMotion::default(),
-                                text: None,
+                                ..default()
                             });
                         }
                         Faction::Neutral => {}

--- a/src/spawnable/projectile/behavior.rs
+++ b/src/spawnable/projectile/behavior.rs
@@ -1,12 +1,8 @@
-use std::thread::spawn;
-
 use crate::{
     assets::GameAudioAssets,
     audio,
     collision::SortedCollisionEvent,
-    spawnable::{
-        InitialMotion, MobComponent, MobSegmentComponent, PlayerComponent, SpawnEffectEvent,
-    },
+    spawnable::{MobComponent, MobSegmentComponent, PlayerComponent, SpawnEffectEvent},
 };
 use bevy::prelude::*;
 use bevy_kira_audio::prelude::*;
@@ -210,6 +206,8 @@ fn deal_damage_on_contact(
                     for (mob_entity_q, mob_transform, mut mob_component) in mob_query.iter_mut() {
                         if *mob_entity == mob_entity_q && *projectile_damage > 0.0 {
                             mob_component.health.take_damage(*projectile_damage);
+
+                            // spawn damage dealt text effect
                             spawn_effect_event_writer.send(SpawnEffectEvent {
                                 effect_type: EffectType::Text(TextEffectType::DamageDealt),
                                 transform: Transform {
@@ -247,6 +245,8 @@ fn deal_damage_on_contact(
                     {
                         if *mob_segment_entity == mob_segment_entity_q && *projectile_damage > 0.0 {
                             mob_segment_component.health.take_damage(*projectile_damage);
+
+                            // spawn damage dealt text effect
                             spawn_effect_event_writer.send(SpawnEffectEvent {
                                 effect_type: EffectType::Text(TextEffectType::DamageDealt),
                                 transform: Transform {
@@ -324,6 +324,8 @@ fn deal_damage_on_intersection(
                     for (mob_entity_q, mob_transform, mut mob_component) in mob_query.iter_mut() {
                         if *mob_entity == mob_entity_q && *projectile_damage > 0.0 {
                             mob_component.health.take_damage(*projectile_damage);
+
+                            // spawn damage dealt text effect
                             spawn_effect_event_writer.send(SpawnEffectEvent {
                                 effect_type: EffectType::Text(TextEffectType::DamageDealt),
                                 transform: Transform {
@@ -360,6 +362,8 @@ fn deal_damage_on_intersection(
                     {
                         if *mob_segment_entity == mob_segment_entity_q && *projectile_damage > 0.0 {
                             mob_segment_component.health.take_damage(*projectile_damage);
+
+                            // spawn damage dealt text effect
                             spawn_effect_event_writer.send(SpawnEffectEvent {
                                 effect_type: EffectType::Text(TextEffectType::DamageDealt),
                                 transform: Transform {

--- a/src/spawnable/projectile/behavior.rs
+++ b/src/spawnable/projectile/behavior.rs
@@ -153,6 +153,7 @@ pub fn projectile_execute_behavior_system(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn deal_damage_on_contact(
     entity: Entity,
     collision_events: &[&SortedCollisionEvent],
@@ -265,6 +266,7 @@ fn deal_damage_on_contact(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn deal_damage_on_intersection(
     entity: Entity,
     collision_events: &[&SortedCollisionEvent],
@@ -422,7 +424,7 @@ fn explode_on_intersection(
                 projectile_entity,
                 mob_faction,
                 projectile_faction,
-                projectile_damage,
+                projectile_damage: _,
                 projectile_source: _,
             } => {
                 if entity == *projectile_entity
@@ -471,7 +473,7 @@ fn explode_on_intersection(
                 projectile_entity,
                 mob_segment_faction,
                 projectile_faction,
-                projectile_damage,
+                projectile_damage: _,
             } => {
                 if entity == *projectile_entity
                     && !match mob_segment_faction {
@@ -567,7 +569,7 @@ fn explode_on_contact(
                 projectile_entity,
                 mob_faction: _,
                 projectile_faction,
-                projectile_damage,
+                projectile_damage: _,
                 projectile_source: _,
             } => {
                 if entity == *projectile_entity {
@@ -611,7 +613,7 @@ fn explode_on_contact(
                 projectile_entity,
                 mob_segment_faction: _,
                 projectile_faction,
-                projectile_damage,
+                projectile_damage: _,
             } => {
                 if entity == *projectile_entity {
                     audio_channel.play(audio_assets.mob_hit.clone());

--- a/src/spawnable/projectile/behavior.rs
+++ b/src/spawnable/projectile/behavior.rs
@@ -403,6 +403,15 @@ fn explode_on_intersection(
                                 },
                                 initial_motion: InitialMotion::default(),
                             });
+                            spawn_effect_event_writer.send(SpawnEffectEvent {
+                                effect_type: EffectType::DamageNumber(100),
+                                transform: Transform {
+                                    translation: transform.translation,
+                                    scale: transform.scale,
+                                    ..Default::default()
+                                },
+                                initial_motion: InitialMotion::default(),
+                            });
                         }
                         Faction::Enemy => {
                             // spawn explosion
@@ -444,6 +453,15 @@ fn explode_on_intersection(
                             // spawn explosion
                             spawn_effect_event_writer.send(SpawnEffectEvent {
                                 effect_type: EffectType::AllyBlastExplosion,
+                                transform: Transform {
+                                    translation: transform.translation,
+                                    scale: transform.scale,
+                                    ..Default::default()
+                                },
+                                initial_motion: InitialMotion::default(),
+                            });
+                            spawn_effect_event_writer.send(SpawnEffectEvent {
+                                effect_type: EffectType::DamageNumber(100),
                                 transform: Transform {
                                     translation: transform.translation,
                                     scale: transform.scale,
@@ -542,6 +560,15 @@ fn explode_on_contact(
                                 },
                                 initial_motion: InitialMotion::default(),
                             });
+                            spawn_effect_event_writer.send(SpawnEffectEvent {
+                                effect_type: EffectType::DamageNumber(100),
+                                transform: Transform {
+                                    translation: transform.translation,
+                                    scale: transform.scale,
+                                    ..Default::default()
+                                },
+                                initial_motion: InitialMotion::default(),
+                            });
                         }
                         Faction::Enemy => {
                             // spawn explosion
@@ -578,6 +605,15 @@ fn explode_on_contact(
                             // spawn explosion
                             spawn_effect_event_writer.send(SpawnEffectEvent {
                                 effect_type: EffectType::AllyBulletExplosion,
+                                transform: Transform {
+                                    translation: transform.translation,
+                                    scale: transform.scale,
+                                    ..Default::default()
+                                },
+                                initial_motion: InitialMotion::default(),
+                            });
+                            spawn_effect_event_writer.send(SpawnEffectEvent {
+                                effect_type: EffectType::DamageNumber(100),
                                 transform: Transform {
                                     translation: transform.translation,
                                     scale: transform.scale,

--- a/src/spawnable/projectile/behavior.rs
+++ b/src/spawnable/projectile/behavior.rs
@@ -11,7 +11,7 @@ use crate::{
 use bevy::prelude::*;
 use bevy_kira_audio::prelude::*;
 use serde::Deserialize;
-use thetawave_interface::spawnable::{EffectType, Faction, ProjectileType};
+use thetawave_interface::spawnable::{EffectType, Faction, ProjectileType, TextEffectType};
 
 use super::ProjectileComponent;
 
@@ -102,6 +102,7 @@ pub fn projectile_execute_behavior_system(
                                             ..Default::default()
                                         },
                                         initial_motion: InitialMotion::default(),
+                                        text: None,
                                     });
                                 }
                                 Faction::Ally => {
@@ -113,6 +114,7 @@ pub fn projectile_execute_behavior_system(
                                             ..Default::default()
                                         },
                                         initial_motion: InitialMotion::default(),
+                                        text: None,
                                     });
                                 }
                                 _ => {}
@@ -127,6 +129,7 @@ pub fn projectile_execute_behavior_system(
                                             ..Default::default()
                                         },
                                         initial_motion: InitialMotion::default(),
+                                        text: None,
                                     });
                                 }
 
@@ -139,6 +142,7 @@ pub fn projectile_execute_behavior_system(
                                             ..Default::default()
                                         },
                                         initial_motion: InitialMotion::default(),
+                                        text: None,
                                     });
                                 }
                                 _ => {}
@@ -211,13 +215,14 @@ fn deal_damage_on_contact(
                         if *mob_entity == mob_entity_q && *projectile_damage > 0.0 {
                             mob_component.health.take_damage(*projectile_damage);
                             spawn_effect_event_writer.send(SpawnEffectEvent {
-                                effect_type: EffectType::DamageText(projectile_damage.to_string()),
+                                effect_type: EffectType::Text(TextEffectType::DamageDealt),
                                 transform: Transform {
                                     translation: mob_transform.translation,
                                     scale: mob_transform.scale,
                                     ..Default::default()
                                 },
                                 initial_motion: InitialMotion::default(),
+                                text: Some(projectile_damage.to_string()),
                             });
                         }
                     }
@@ -247,13 +252,14 @@ fn deal_damage_on_contact(
                         if *mob_segment_entity == mob_segment_entity_q && *projectile_damage > 0.0 {
                             mob_segment_component.health.take_damage(*projectile_damage);
                             spawn_effect_event_writer.send(SpawnEffectEvent {
-                                effect_type: EffectType::DamageText(projectile_damage.to_string()),
+                                effect_type: EffectType::Text(TextEffectType::DamageDealt),
                                 transform: Transform {
                                     translation: mob_segment_transform.translation,
                                     scale: mob_segment_transform.scale,
                                     ..Default::default()
                                 },
                                 initial_motion: InitialMotion::default(),
+                                text: Some(projectile_damage.to_string()),
                             });
                         }
                     }
@@ -323,13 +329,14 @@ fn deal_damage_on_intersection(
                         if *mob_entity == mob_entity_q && *projectile_damage > 0.0 {
                             mob_component.health.take_damage(*projectile_damage);
                             spawn_effect_event_writer.send(SpawnEffectEvent {
-                                effect_type: EffectType::DamageText(projectile_damage.to_string()),
+                                effect_type: EffectType::Text(TextEffectType::DamageDealt),
                                 transform: Transform {
                                     translation: mob_transform.translation,
                                     scale: mob_transform.scale,
                                     ..Default::default()
                                 },
                                 initial_motion: InitialMotion::default(),
+                                text: Some(projectile_damage.to_string()),
                             });
                         }
                     }
@@ -358,13 +365,14 @@ fn deal_damage_on_intersection(
                         if *mob_segment_entity == mob_segment_entity_q && *projectile_damage > 0.0 {
                             mob_segment_component.health.take_damage(*projectile_damage);
                             spawn_effect_event_writer.send(SpawnEffectEvent {
-                                effect_type: EffectType::DamageText(projectile_damage.to_string()),
+                                effect_type: EffectType::Text(TextEffectType::DamageDealt),
                                 transform: Transform {
                                     translation: mob_segment_transform.translation,
                                     scale: mob_segment_transform.scale,
                                     ..Default::default()
                                 },
                                 initial_motion: InitialMotion::default(),
+                                text: Some(projectile_damage.to_string()),
                             });
                         }
                     }
@@ -410,6 +418,7 @@ fn explode_on_intersection(
                             ..Default::default()
                         },
                         initial_motion: InitialMotion::default(),
+                        text: None,
                     });
 
                     // despawn blast
@@ -446,6 +455,7 @@ fn explode_on_intersection(
                                     ..Default::default()
                                 },
                                 initial_motion: InitialMotion::default(),
+                                text: None,
                             });
                         }
                         Faction::Enemy => {
@@ -458,6 +468,7 @@ fn explode_on_intersection(
                                     ..Default::default()
                                 },
                                 initial_motion: InitialMotion::default(),
+                                text: None,
                             });
                         }
                         Faction::Neutral => {}
@@ -494,6 +505,7 @@ fn explode_on_intersection(
                                     ..Default::default()
                                 },
                                 initial_motion: InitialMotion::default(),
+                                text: None,
                             });
                         }
                         Faction::Enemy => {
@@ -506,6 +518,7 @@ fn explode_on_intersection(
                                     ..Default::default()
                                 },
                                 initial_motion: InitialMotion::default(),
+                                text: None,
                             });
                         }
                         Faction::Neutral => {}
@@ -555,6 +568,7 @@ fn explode_on_contact(
                             ..Default::default()
                         },
                         initial_motion: InitialMotion::default(),
+                        text: None,
                     });
 
                     // despawn blast
@@ -585,6 +599,7 @@ fn explode_on_contact(
                                     ..Default::default()
                                 },
                                 initial_motion: InitialMotion::default(),
+                                text: None,
                             });
                         }
                         Faction::Enemy => {
@@ -597,6 +612,7 @@ fn explode_on_contact(
                                     ..Default::default()
                                 },
                                 initial_motion: InitialMotion::default(),
+                                text: None,
                             });
                         }
                         Faction::Neutral => {}
@@ -628,6 +644,7 @@ fn explode_on_contact(
                                     ..Default::default()
                                 },
                                 initial_motion: InitialMotion::default(),
+                                text: None,
                             });
                         }
                         Faction::Enemy => {
@@ -640,6 +657,7 @@ fn explode_on_contact(
                                     ..Default::default()
                                 },
                                 initial_motion: InitialMotion::default(),
+                                text: None,
                             });
                         }
                         Faction::Neutral => {}
@@ -670,6 +688,7 @@ fn explode_on_contact(
                                     ..Default::default()
                                 },
                                 initial_motion: InitialMotion::default(),
+                                text: None,
                             });
                         }
                         Faction::Enemy => {
@@ -682,6 +701,7 @@ fn explode_on_contact(
                                     ..Default::default()
                                 },
                                 initial_motion: InitialMotion::default(),
+                                text: None,
                             });
                         }
                         Faction::Neutral => {}

--- a/src/spawnable/projectile/behavior.rs
+++ b/src/spawnable/projectile/behavior.rs
@@ -380,7 +380,7 @@ fn explode_on_intersection(
                 projectile_entity,
                 mob_faction,
                 projectile_faction,
-                projectile_damage: _,
+                projectile_damage,
                 projectile_source: _,
             } => {
                 if entity == *projectile_entity
@@ -404,7 +404,7 @@ fn explode_on_intersection(
                                 initial_motion: InitialMotion::default(),
                             });
                             spawn_effect_event_writer.send(SpawnEffectEvent {
-                                effect_type: EffectType::DamageNumber(100),
+                                effect_type: EffectType::DamageText(projectile_damage.to_string()),
                                 transform: Transform {
                                     translation: transform.translation,
                                     scale: transform.scale,
@@ -438,7 +438,7 @@ fn explode_on_intersection(
                 projectile_entity,
                 mob_segment_faction,
                 projectile_faction,
-                projectile_damage: _,
+                projectile_damage,
             } => {
                 if entity == *projectile_entity
                     && !match mob_segment_faction {
@@ -461,7 +461,7 @@ fn explode_on_intersection(
                                 initial_motion: InitialMotion::default(),
                             });
                             spawn_effect_event_writer.send(SpawnEffectEvent {
-                                effect_type: EffectType::DamageNumber(100),
+                                effect_type: EffectType::DamageText(projectile_damage.to_string()),
                                 transform: Transform {
                                     translation: transform.translation,
                                     scale: transform.scale,
@@ -543,7 +543,7 @@ fn explode_on_contact(
                 projectile_entity,
                 mob_faction: _,
                 projectile_faction,
-                projectile_damage: _,
+                projectile_damage,
                 projectile_source: _,
             } => {
                 if entity == *projectile_entity {
@@ -561,7 +561,7 @@ fn explode_on_contact(
                                 initial_motion: InitialMotion::default(),
                             });
                             spawn_effect_event_writer.send(SpawnEffectEvent {
-                                effect_type: EffectType::DamageNumber(100),
+                                effect_type: EffectType::DamageText(projectile_damage.to_string()),
                                 transform: Transform {
                                     translation: transform.translation,
                                     scale: transform.scale,
@@ -596,7 +596,7 @@ fn explode_on_contact(
                 projectile_entity,
                 mob_segment_faction: _,
                 projectile_faction,
-                projectile_damage: _,
+                projectile_damage,
             } => {
                 if entity == *projectile_entity {
                     audio_channel.play(audio_assets.mob_hit.clone());
@@ -613,7 +613,7 @@ fn explode_on_contact(
                                 initial_motion: InitialMotion::default(),
                             });
                             spawn_effect_event_writer.send(SpawnEffectEvent {
-                                effect_type: EffectType::DamageNumber(100),
+                                effect_type: EffectType::DamageText(projectile_damage.to_string()),
                                 transform: Transform {
                                     translation: transform.translation,
                                     scale: transform.scale,


### PR DESCRIPTION
- Damage numbers appear when mobs and mob segments are dealt damage from collisions and intersections
- Info text appears when consumables are collected