### PR TITLE
Fix/persist total shots hit to compute accuracy across all games

### DIFF
--- a/crates/thetawave_storage/src/plugin.rs
+++ b/crates/thetawave_storage/src/plugin.rs
@@ -176,14 +176,18 @@ mod test {
             MobsKilledBy1PlayerCacheT::from([(EnemyMobType::Drone, N_DRONES)]),
         );
     }
-    fn set_n_games_lost_by_player_in_user_stats_cache<const N_GAMES_LOST: usize>(
+    fn set_user_stats_for_completed_games<
+        const N_GAMES_LOST: usize,
+        const TOTAL_SHOTS_HIT: usize,
+        const TOTAL_SHOTS_FIRED: usize,
+    >(
         mut historical_user_stats: ResMut<UserStatsByPlayerForCompletedGamesCache>,
     ) {
         (**historical_user_stats).insert(
             DEFAULT_USER_ID,
             UserStat {
-                total_shots_fired: 0,
-                total_shots_hit: 0,
+                total_shots_fired: TOTAL_SHOTS_FIRED,
+                total_shots_hit: TOTAL_SHOTS_HIT,
                 total_games_lost: N_GAMES_LOST,
             },
         );
@@ -204,6 +208,8 @@ mod test {
     fn _test_can_flush_caches_to_db() {
         const N_DRONES_KILLED: usize = 15;
         const N_GAMES_PLAYED: usize = 2;
+        const TOTAL_SHOTS_HIT: usize = 10;
+        const TOTAL_SHOTS_FIRED: usize = 15;
 
         let mob_kills_after_1_game =
             MobKillsByPlayerForCompletedGames::from(MobsKilledByPlayerCacheT::from([(
@@ -216,7 +222,11 @@ mod test {
                 OnEnter(AppStates::Game),
                 (
                     set_n_drones_killed_for_p1_in_completed_games_cache::<N_DRONES_KILLED>,
-                    set_n_games_lost_by_player_in_user_stats_cache::<N_GAMES_PLAYED>,
+                    set_user_stats_for_completed_games::<
+                        N_GAMES_PLAYED,
+                        TOTAL_SHOTS_HIT,
+                        TOTAL_SHOTS_FIRED,
+                    >,
                 ),
             )
             .add_systems(OnEnter(AppStates::Game), set_game_over_state)
@@ -229,8 +239,8 @@ mod test {
         assert_eq!(
             get_user_stats(DEFAULT_USER_ID).unwrap(),
             UserStat {
-                total_shots_fired: 0,
-                total_shots_hit: 0,
+                total_shots_fired: TOTAL_SHOTS_FIRED,
+                total_shots_hit: TOTAL_SHOTS_HIT,
                 total_games_lost: N_GAMES_PLAYED,
             }
         );

--- a/crates/thetawave_storage/src/user_stats.rs
+++ b/crates/thetawave_storage/src/user_stats.rs
@@ -11,9 +11,9 @@ pub(super) fn set_user_stats_for_user_id(
 ) -> Result<(), OurDBError> {
     let stmt_raw = format!(
         "
-    INSERT OR REPLACE INTO {USERSTAT} (userId, totalShotsFired, totalGamesLost)
-    VALUES (?1,  ?2, ?3)
-    ON CONFLICT DO UPDATE SET totalShotsFired=?2, totalGamesLost=?3"
+    INSERT OR REPLACE INTO {USERSTAT} (userId, totalShotsFired, totalGamesLost, totalShotsHit)
+    VALUES (?1,  ?2, ?3, ?4)
+    ON CONFLICT DO UPDATE SET totalShotsFired=?2, totalGamesLost=?3, totalShotsHit=?4"
     );
     let conn = get_db()?;
     info!(
@@ -23,7 +23,8 @@ pub(super) fn set_user_stats_for_user_id(
     conn.prepare(&stmt_raw)?.execute(params![
         user_id,
         user_stats.total_shots_fired,
-        user_stats.total_games_lost
+        user_stats.total_games_lost,
+        user_stats.total_shots_hit,
     ])?;
     Ok(())
 }


### PR DESCRIPTION
The main menu always shows accuracy = 0%. I forgot to include that field in the ones we persist to sqlite. The changes to the tests will fail without the corresponding code change. 
```
     Running unittests src/lib.rs (target/debug/deps/thetawave_storage-9d08f2ece7e32511)

running 1 test
2023-08-17T17:23:57.975751Z  INFO thetawave_storage::core: Created sqlite db
2023-08-17T17:23:57.976845Z  INFO thetawave_storage::plugin: Flushing mob kills to db {0: {Drone: 15}}
2023-08-17T17:23:57.977033Z  INFO thetawave_storage::user_stats: Preparing db upsert
    INSERT OR REPLACE INTO UserStat (userId, totalShotsFired, totalGamesLost)
    VALUES (?1,  ?2, ?3)
    ON CONFLICT DO UPDATE SET totalShotsFired=?2, totalGamesLost=?3 with param n_shots=15
test plugin::test::test_recover_resources_from_db_after_mock_program_restart ... FAILED

failures:

---- plugin::test::test_recover_resources_from_db_after_mock_program_restart stdout ----
thread 'plugin::test::test_recover_resources_from_db_after_mock_program_restart' panicked at 'assertion failed: `(left == right)`
  left: `UserStat { total_shots_fired: 15, total_shots_hit: 0, total_games_lost: 2 }`,
 right: `UserStat { total_shots_fired: 15, total_shots_hit: 10, total_games_lost: 2 }`', crates/thetawave_storage/src/plugin.rs:231:9
```