### PR TITLE
constant time contact dynamic dispatch queries 

### DIFF
--- a/src/collision/contact.rs
+++ b/src/collision/contact.rs
@@ -69,15 +69,13 @@ pub fn contact_collision_system(
                     });
                     continue 'collision_events;
                 }
-
                 // check if player collided with a barrier
-                if barrier_query.get(colliding_entities.secondary).is_ok() {
+                else if barrier_query.get(colliding_entities.secondary).is_ok() {
                     audio_channel.play(audio_assets.barrier_bounce.clone());
                     continue 'collision_events;
                 }
-
                 // check if player collided with segment
-                if let Ok((_mob_segment_entity, mob_segment_component)) =
+                else if let Ok((_mob_segment_entity, mob_segment_component)) =
                     mob_segment_query.get(colliding_entities.secondary)
                 {
                     audio_channel.play(
@@ -97,8 +95,7 @@ pub fn contact_collision_system(
                     continue 'collision_events;
                 }
                 // check if player collided with a projectile
-
-                if let Ok((_projectile_entity, projectile_component)) =
+                else if let Ok((_projectile_entity, projectile_component)) =
                     projectile_query.get(colliding_entities.secondary)
                 {
                     collision_event_writer.send(SortedCollisionEvent::PlayerToProjectileContact {
@@ -114,9 +111,9 @@ pub fn contact_collision_system(
                     continue 'collision_events;
                 }
             }
-
             // check if mob was the 'most important thing' that was in the collision
-            if let Ok((_mob_entity_1, mob_component_1)) = mob_query.get(colliding_entities.primary)
+            else if let Ok((_mob_entity_1, mob_component_1)) =
+                mob_query.get(colliding_entities.primary)
             {
                 // check if mob collided with other mob
                 if let Ok((_mob_entity, mob_component_2)) =
@@ -171,9 +168,8 @@ pub fn contact_collision_system(
                     });
                     continue 'collision_events;
                 }
-
                 // check if mob collided with barrier
-                if let Ok(barrier_entity) = barrier_query.get(colliding_entities.secondary) {
+                else if let Ok(barrier_entity) = barrier_query.get(colliding_entities.secondary) {
                     collision_event_writer.send(SortedCollisionEvent::MobToBarrierContact {
                         mob_entity: colliding_entities.primary,
                         barrier_entity,
@@ -182,7 +178,7 @@ pub fn contact_collision_system(
                     continue 'collision_events;
                 }
                 // check if mob collided with mob segment
-                if let Ok((_mob_segment_entity, mob_segment_component)) =
+                else if let Ok((_mob_segment_entity, mob_segment_component)) =
                     mob_segment_query.get(colliding_entities.secondary)
                 {
                     if mob_component_1.collision_sound != CollisionSoundType::default() {
@@ -217,7 +213,7 @@ pub fn contact_collision_system(
                     continue 'collision_events;
                 }
                 // check if mob collided with projectile
-                if let Ok((_projectile_entity, projectile_component)) =
+                else if let Ok((_projectile_entity, projectile_component)) =
                     projectile_query.get(colliding_entities.secondary)
                 {
                     collision_event_writer.send(SortedCollisionEvent::MobToProjectileContact {
@@ -238,9 +234,8 @@ pub fn contact_collision_system(
                     continue 'collision_events;
                 }
             }
-
             // check if mob segment was the 'most important thing' that was in the collision
-            if let Ok((_mob_segment_entity_1, mob_segment_component_1)) =
+            else if let Ok((_mob_segment_entity_1, mob_segment_component_1)) =
                 mob_segment_query.get(colliding_entities.primary)
             {
                 // check if mob segment collided with other mob segment
@@ -300,9 +295,8 @@ pub fn contact_collision_system(
                     );
                     continue 'collision_events;
                 }
-
                 // check if mob segment collided with projectile
-                if let Ok((_projectile_entity, projectile_component)) =
+                else if let Ok((_projectile_entity, projectile_component)) =
                     projectile_query.get(colliding_entities.secondary)
                 {
                     audio_channel.play(audio_assets.bullet_bounce.clone());
@@ -324,16 +318,14 @@ pub fn contact_collision_system(
                     );
                     continue 'collision_events;
                 }
-
                 // check if mob segment collided with barrier
-                if barrier_query.get(colliding_entities.secondary).is_ok() {
+                else if barrier_query.get(colliding_entities.secondary).is_ok() {
                     audio_channel.play(audio_assets.barrier_bounce.clone());
                     continue 'collision_events;
                 }
             }
-
             // check if projectile was the 'most important thing' that was in the collision
-            if let Ok((projectile_entity_1, projectile_component_1)) =
+            else if let Ok((projectile_entity_1, projectile_component_1)) =
                 projectile_query.get(colliding_entities.primary)
             {
                 // check if the projectile collided with another projectile

--- a/src/collision/contact.rs
+++ b/src/collision/contact.rs
@@ -49,25 +49,24 @@ pub fn contact_collision_system(
                 // check if colliding entities were found
                 if let Some(colliding_entities) = colliding_entities {
                     // check if player collided with a mob
-                    for (mob_entity, mob_component) in mob_query.iter() {
-                        if colliding_entities.secondary == mob_entity {
-                            audio_channel.play(
-                                audio_assets
-                                    .get_collision_sound_asset(&mob_component.collision_sound),
-                            );
-                            collision_event_writer.send(SortedCollisionEvent::PlayerToMobContact {
-                                player_entity: colliding_entities.primary,
-                                mob_entity: colliding_entities.secondary,
-                                mob_faction: match mob_component.mob_type.clone() {
-                                    MobType::Enemy(_) => Faction::Enemy,
-                                    MobType::Ally(_) => Faction::Ally,
-                                    MobType::Neutral(_) => Faction::Neutral,
-                                },
-                                player_damage: player_component.collision_damage,
-                                mob_damage: mob_component.collision_damage,
-                            });
-                            continue 'collision_events;
-                        }
+                    if let Ok((_entity, mob_component)) =
+                        mob_query.get(colliding_entities.secondary)
+                    {
+                        audio_channel.play(
+                            audio_assets.get_collision_sound_asset(&mob_component.collision_sound),
+                        );
+                        collision_event_writer.send(SortedCollisionEvent::PlayerToMobContact {
+                            player_entity: colliding_entities.primary,
+                            mob_entity: colliding_entities.secondary,
+                            mob_faction: match mob_component.mob_type.clone() {
+                                MobType::Enemy(_) => Faction::Enemy,
+                                MobType::Ally(_) => Faction::Ally,
+                                MobType::Neutral(_) => Faction::Neutral,
+                            },
+                            player_damage: player_component.collision_damage,
+                            mob_damage: mob_component.collision_damage,
+                        });
+                        continue 'collision_events;
                     }
 
                     // check if player collided with a barrier

--- a/src/collision/instersection.rs
+++ b/src/collision/instersection.rs
@@ -65,7 +65,7 @@ pub fn intersection_collision_system(
                     continue 'collision_events;
                 }
                 // check for player-consumable intersection
-                if consumable_query.get(colliding_entities.secondary).is_ok() {
+                else if consumable_query.get(colliding_entities.secondary).is_ok() {
                     collision_event_writer.send(
                         SortedCollisionEvent::PlayerToConsumableIntersection {
                             player_entity: colliding_entities.primary,
@@ -75,9 +75,10 @@ pub fn intersection_collision_system(
                     continue 'collision_events;
                 }
             }
-
             // check of mob was collided with
-            if let Ok((_mob_entity, mob_component)) = mob_query.get(colliding_entities.primary) {
+            else if let Ok((_mob_entity, mob_component)) =
+                mob_query.get(colliding_entities.primary)
+            {
                 // check for mob-to-projectile intersection
                 if let Ok((_projectile_entity, projectile_component)) =
                     projectile_query.get(colliding_entities.secondary)
@@ -102,9 +103,8 @@ pub fn intersection_collision_system(
                     continue 'collision_events;
                 }
             }
-
             // check if mob segment was collided with
-            if let Ok((_mob_segment_entity, mob_segment_component)) =
+            else if let Ok((_mob_segment_entity, mob_segment_component)) =
                 mob_segment_query.get(colliding_entities.primary)
             {
                 // check for mobSegment-to-projectile intersection

--- a/src/collision/instersection.rs
+++ b/src/collision/instersection.rs
@@ -27,153 +27,106 @@ pub fn intersection_collision_system(
             CollisionEventFlags::SENSOR,
         ) = collision_event
         {
+            // 'Canonicalized' pair to deal with/normalize out E.x. (mob, player) vs (player, mob)
+            // intersection symmetry of pattern match arms.
+            let colliding_entities = {
+                let mut entities = [collider1_entity.clone(), collider2_entity.clone()];
+                entities.sort_by_key(|e| {
+                    (
+                        // (0,...,1) ascending ordering.
+                        player_query.get(*e).is_ok(), // Most important. Check first
+                        mob_query.get(*e).is_ok(),
+                        mob_segment_query.get(*e).is_ok(),
+                        projectile_query.get(*e).is_ok(), // least important thing to check.
+                    )
+                });
+                CollidingEntityPair {
+                    primary: entities[1].clone(),
+                    secondary: entities[0].clone(),
+                }
+            };
             //check if player was collided with
-            for player_entity in player_query.iter() {
-                // first entity is player second, is the other colliding entity
-                let colliding_entities: Option<CollidingEntityPair> =
-                    if player_entity == *collider1_entity {
-                        Some(CollidingEntityPair {
-                            primary: *collider1_entity,
-                            secondary: *collider2_entity,
-                        })
-                    } else if player_entity == *collider2_entity {
-                        Some(CollidingEntityPair {
-                            primary: *collider2_entity,
-                            secondary: *collider1_entity,
-                        })
-                    } else {
-                        None
-                    };
-
-                if let Some(colliding_entities) = colliding_entities {
-                    // check for projectile
-                    for (projectile_entity, projectile_component) in projectile_query.iter() {
-                        if colliding_entities.secondary == projectile_entity {
-                            collision_event_writer.send(
-                                SortedCollisionEvent::PlayerToProjectileIntersection {
-                                    player_entity: colliding_entities.primary,
-                                    projectile_entity: colliding_entities.secondary,
-                                    projectile_faction: match projectile_component
-                                        .projectile_type
-                                        .clone()
-                                    {
-                                        ProjectileType::Blast(faction) => faction,
-                                        ProjectileType::Bullet(faction) => faction,
-                                    },
-                                    projectile_damage: projectile_component.damage,
-                                },
-                            );
-                            continue 'collision_events;
-                        }
-                    }
-                    // check for consumable
-                    for consumable_entity in consumable_query.iter() {
-                        if colliding_entities.secondary == consumable_entity {
-                            collision_event_writer.send(
-                                SortedCollisionEvent::PlayerToConsumableIntersection {
-                                    player_entity: colliding_entities.primary,
-                                    consumable_entity: colliding_entities.secondary,
-                                },
-                            );
-                            continue 'collision_events;
-                        }
-                    }
+            if player_query.get(colliding_entities.primary).is_ok() {
+                // check for player-to-projectile intersection
+                if let Ok((_projectile_entity, projectile_component)) =
+                    projectile_query.get(colliding_entities.secondary)
+                {
+                    collision_event_writer.send(
+                        SortedCollisionEvent::PlayerToProjectileIntersection {
+                            player_entity: colliding_entities.primary,
+                            projectile_entity: colliding_entities.secondary,
+                            projectile_faction: match projectile_component.projectile_type.clone() {
+                                ProjectileType::Blast(faction) => faction,
+                                ProjectileType::Bullet(faction) => faction,
+                            },
+                            projectile_damage: projectile_component.damage,
+                        },
+                    );
+                    continue 'collision_events;
+                }
+                // check for player-consumable intersection
+                if consumable_query.get(colliding_entities.secondary).is_ok() {
+                    collision_event_writer.send(
+                        SortedCollisionEvent::PlayerToConsumableIntersection {
+                            player_entity: colliding_entities.primary,
+                            consumable_entity: colliding_entities.secondary,
+                        },
+                    );
+                    continue 'collision_events;
                 }
             }
 
             // check of mob was collided with
-            for (mob_entity, mob_component) in mob_query.iter() {
-                // first entity is mob, second is the other colliding entity
-                let colliding_entities: Option<CollidingEntityPair> =
-                    if mob_entity == *collider1_entity {
-                        Some(CollidingEntityPair {
-                            primary: *collider1_entity,
-                            secondary: *collider2_entity,
-                        })
-                    } else if mob_entity == *collider2_entity {
-                        Some(CollidingEntityPair {
-                            primary: *collider2_entity,
-                            secondary: *collider1_entity,
-                        })
-                    } else {
-                        None
-                    };
-
-                if let Some(colliding_entities) = colliding_entities {
-                    // check for projectile
-                    for (projectile_entity, projectile_component) in projectile_query.iter() {
-                        if colliding_entities.secondary == projectile_entity {
-                            collision_event_writer.send(
-                                SortedCollisionEvent::MobToProjectileIntersection {
-                                    projectile_source: projectile_component.source,
-                                    mob_entity: colliding_entities.primary,
-                                    projectile_entity: colliding_entities.secondary,
-                                    mob_faction: match mob_component.mob_type {
-                                        MobType::Enemy(_) => Faction::Enemy,
-                                        MobType::Ally(_) => Faction::Ally,
-                                        MobType::Neutral(_) => Faction::Neutral,
-                                    },
-                                    projectile_faction: match projectile_component
-                                        .projectile_type
-                                        .clone()
-                                    {
-                                        ProjectileType::Blast(faction) => faction,
-                                        ProjectileType::Bullet(faction) => faction,
-                                    },
-                                    projectile_damage: projectile_component.damage,
-                                },
-                            );
-                            continue 'collision_events;
-                        }
-                    }
+            if let Ok((_mob_entity, mob_component)) = mob_query.get(colliding_entities.primary) {
+                // check for mob-to-projectile intersection
+                if let Ok((_projectile_entity, projectile_component)) =
+                    projectile_query.get(colliding_entities.secondary)
+                {
+                    collision_event_writer.send(
+                        SortedCollisionEvent::MobToProjectileIntersection {
+                            projectile_source: projectile_component.source,
+                            mob_entity: colliding_entities.primary,
+                            projectile_entity: colliding_entities.secondary,
+                            mob_faction: match mob_component.mob_type {
+                                MobType::Enemy(_) => Faction::Enemy,
+                                MobType::Ally(_) => Faction::Ally,
+                                MobType::Neutral(_) => Faction::Neutral,
+                            },
+                            projectile_faction: match projectile_component.projectile_type.clone() {
+                                ProjectileType::Blast(faction) => faction,
+                                ProjectileType::Bullet(faction) => faction,
+                            },
+                            projectile_damage: projectile_component.damage,
+                        },
+                    );
+                    continue 'collision_events;
                 }
             }
 
             // check if mob segment was collided with
-            for (mob_segment_entity, mob_segment_component) in mob_segment_query.iter() {
-                // first entity is mob_segment, second is the other colliding entity
-                let colliding_entities: Option<CollidingEntityPair> =
-                    if mob_segment_entity == *collider1_entity {
-                        Some(CollidingEntityPair {
-                            primary: *collider1_entity,
-                            secondary: *collider2_entity,
-                        })
-                    } else if mob_segment_entity == *collider2_entity {
-                        Some(CollidingEntityPair {
-                            primary: *collider2_entity,
-                            secondary: *collider1_entity,
-                        })
-                    } else {
-                        None
-                    };
-
-                if let Some(colliding_entities) = colliding_entities {
-                    // check for projectile
-                    for (projectile_entity, projectile_component) in projectile_query.iter() {
-                        if colliding_entities.secondary == projectile_entity {
-                            collision_event_writer.send(
-                                SortedCollisionEvent::MobSegmentToProjectileIntersection {
-                                    mob_segment_entity: colliding_entities.primary,
-                                    projectile_entity: colliding_entities.secondary,
-                                    mob_segment_faction: match mob_segment_component
-                                        .mob_segment_type
-                                    {
-                                        MobSegmentType::Neutral(_) => Faction::Neutral,
-                                        MobSegmentType::Enemy(_) => Faction::Enemy,
-                                    },
-                                    projectile_faction: match projectile_component
-                                        .projectile_type
-                                        .clone()
-                                    {
-                                        ProjectileType::Blast(faction) => faction,
-                                        ProjectileType::Bullet(faction) => faction,
-                                    },
-                                    projectile_damage: projectile_component.damage,
-                                },
-                            );
-                            continue 'collision_events;
-                        }
-                    }
+            if let Ok((_mob_segment_entity, mob_segment_component)) =
+                mob_segment_query.get(colliding_entities.primary)
+            {
+                // check for mobSegment-to-projectile intersection
+                if let Ok((_projectile_entity, projectile_component)) =
+                    projectile_query.get(colliding_entities.secondary)
+                {
+                    collision_event_writer.send(
+                        SortedCollisionEvent::MobSegmentToProjectileIntersection {
+                            mob_segment_entity: colliding_entities.primary,
+                            projectile_entity: colliding_entities.secondary,
+                            mob_segment_faction: match mob_segment_component.mob_segment_type {
+                                MobSegmentType::Neutral(_) => Faction::Neutral,
+                                MobSegmentType::Enemy(_) => Faction::Enemy,
+                            },
+                            projectile_faction: match projectile_component.projectile_type.clone() {
+                                ProjectileType::Blast(faction) => faction,
+                                ProjectileType::Bullet(faction) => faction,
+                            },
+                            projectile_damage: projectile_component.damage,
+                        },
+                    );
+                    continue 'collision_events;
                 }
             }
         }


### PR DESCRIPTION
Seriously WTF is this? Why do we do stuff with a `SortedCollisionEvent` struct BUT NEVER CALL `.sort()`. Wild. Ill profile it later. The name on the named for-loop is now extraneous since this function now has 1 for loop. Everything else is now if-statements. Let's talk about what to do next here. Calling `.get()` is definitely the right move over iteration. 

We _must_ take audio out of this function. It is having enough trouble "tagging" collisions and doing dynamic dispatch. There should be an audio effects module that consumes these `SortedCollisionEvent`s 


I think this PR removes 20 for-loops.

I have every reason to believe this is faster because:

calling `query.get(entity_id)` ultimately boils down to an index-based lookup in a `Vec<EntityMeta>`  whereas doing `query.iter().filter(|x| x == other_entity)` loops through a "sparse array" and checks if "an index is in the dense array", which is almost one of the few things sparse arrays are good for in the first place. 