### PR TITLE
Next attempt at netlify GH action

### DIFF
--- a/.github/workflows/web_release.yml
+++ b/.github/workflows/web_release.yml
@@ -1,5 +1,6 @@
 name: Web release -- Netlify
 on:
+  # We will publish to the dev website on pushes to main, with the option of manually cutting a release to the prod website.
   workflow_dispatch:
     inputs:
       deploymentAppTier:
@@ -10,16 +11,26 @@ on:
         options:
         - dev
         - prod
-  push:  # We will publish to the dev website on pushes to main
+  push:  
     branches:
       - main
 env:
   RUST_BACKTRACE: 1
+  APP_TIER: "${{ ((github.event_name == 'workflow_dispatch') && (inputs.deploymentAppTier == 'prod')) && 'PROD' || 'DEV' }}"
 jobs:
   wasm-publish:
-    name: Build and publish WASM-based game to Netlify dev branch
+    name: Build and publish WASM-based game to Netlify
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
     steps:
+      - name: Log App tier
+        id: start
+        run: |
+          set -euxo pipefail
+          echo "Publishing app tier: $APP_TIER"
+          echo "shortGitSha=${GITHUB_SHA:0:7}" >> "$GITHUB_OUTPUT"
       - name: Checkout
         uses: actions/checkout@v3
       - name: Install rust nightly toolchain
@@ -30,32 +41,24 @@ jobs:
         run: |
           set -euxo pipefail
           sudo apt install -y lld g++ pkg-config libx11-dev libasound2-dev libudev-dev binaryen
-        shell: bash
       - name: Build wasm assets
         run: ./build_wasm.sh
-      - name: Publish test deployment to netlify dev site
-        if: "${{ !((github.event_name == 'workflow_dispatch') && (inputs.deploymentAppTier == 'prod')) }}"
-        uses: netlify/actions/cli@master
+      - name: Publish deployment to netlify website
+        id: publish
+        uses: jsmrcaga/action-netlify-deploy@v2.0.0
         with:
-          # It says prod, but this just means that we publish to the 'actual dev site' and opt out of netlify's 'branch
-          # deploys'
-          args: 'deploy --prod --dir=out/ -m "Main branch preview deploy via GH Actions. Git sha: ${{ github.sha }}. Message: ${{ github.event.head_commit.message}}"'
-        env:
-          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_DEV_THETAWAVE_SITE_ID }}
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-      - name: Publish deployment to netlify prod site
-        if: "${{ (github.event_name == 'workflow_dispatch') && (inputs.deploymentAppTier == 'prod') }}"
-        uses: netlify/actions/cli@master
-        with:
-          args: 'deploy --prod --dir=out/ -m "Main branch deploy via GH Actions. Git sha: ${{ github.sha }}. Message: ${{ github.event.head_commit.message}}"'
-        env:
-          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_PROD_THETAWAVE_SITE_ID }}
-          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-  ci-pass:
-    name: CI is green
-    runs-on: ubuntu-latest
-    needs:
-      - wasm-publish
-    steps:
-      - run: exit 0
+          NETLIFY_SITE_ID: ${{ (env.APP_TIER == 'PROD') && secrets.NETLIFY_PROD_THETAWAVE_SITE_ID ||  secrets.NETLIFY_DEV_THETAWAVE_SITE_ID }}
+          NETLIFY_DEPLOY_MESSAGE: >
+            Source: https://github.com/${{github.repository}}/tree/${{ steps.start.outputs.shortGitSha }} 
+            Build: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          NETLIFY_DEPLOY_TO_PROD: true  # This means we opt out of netlify's 'branch deployments' and manage app tiers via separate site ids
+          install_command: "echo Skipping installing the dependencies"
+          build_command: "echo Skipping building the web files"
+          build_directory: "out/"
+      - name: Finish CI
+        run: |
+          set -euxo pipefail
+          echo 'See the website at ${{ steps.publish.outputs.NETLIFY_LIVE_URL }} .'
+          echo 'Immutable site deployment URL : ${{ steps.publish.outputs.NETLIFY_PREVIEW_URL }} .'
 


### PR DESCRIPTION
Use an unofficial netlify GH action to properly handle error states when publishing to CDN. Use a more descriptive deployment message.

With this, I am fairly confident that we can:
- Deploy to dev or prod at the click of a button (and to dev whenever we merge something into the main branch)
- Roll back dev or prod websites to previous versions with the click of a button
- Link every netlify deployment to a source tree (git hash) and github action job.  

![Screenshot from 2023-08-22 08-37-37](https://github.com/thetawavegame/thetawave/assets/22409608/bc50f06d-aa0a-4d2d-aaec-2d41f74768a2)
