### PR TITLE
wasm asset listing from s3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,10 +8,13 @@ members = [
     "crates/thetawave_interface",
     "crates/thetawave_storage",
     "crates/thetawave_arcade",
+    "crates/thetawave_web",
 ]
 
 [workspace.dependencies]
 serde = "1.0.159"
+serde_derive = "1.0.159"
+serde-xml-rs = "0.6"
 strum = "0.25.0"
 strum_macros = "0.25.1"
 bevy = { version = "0.11.2", features = ["serialize"] }
@@ -19,6 +22,11 @@ thiserror = "1.0"
 derive_more  = "0.99.17"
 bevy_ecs_macros = "0.11.2"
 bevy_ecs = "0.11.2"
+bevy_app = "0.11.2"
+bevy_log = "0.11.2"
+bevy_tasks = "0.11.2"
+futures-lite = "1.13.0"
+async-channel = "1.9.0"
 
 [dependencies]
 bevy = {workspace = true}
@@ -51,6 +59,8 @@ thetawave_interface = { path = "crates/thetawave_interface" }
 thetawave_storage = { path = "crates/thetawave_storage", optional = true }
 thetawave_arcade = { path = "crates/thetawave_arcade", optional = true }
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+thetawave_web = { path = "crates/thetawave_web", optional = true }
 
 # optimize dev packages as we don't need them in debug version
 [profile.dev.package."*"]
@@ -66,3 +76,4 @@ codegen-units = 1
 [features]
 arcade = ["thetawave_arcade"]
 storage = ["thetawave_storage"]
+web = ["thetawave_web"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,6 @@ bevy_ecs_macros = "0.11.2"
 bevy_ecs = "0.11.2"
 bevy_app = "0.11.2"
 bevy_log = "0.11.2"
-bevy_tasks = "0.11.2"
-futures-lite = "1.13.0"
 async-channel = "1.9.0"
 
 [dependencies]
@@ -45,7 +43,6 @@ strum = {workspace = true}
 strum_macros = {workspace = true}
 ron = "0.8.0"
 rand = "0.8.5"
-console_error_panic_hook = "0.1.7"
 bevy_kira_audio = { version = "0.16.0", features = ["mp3", "wav"] }
 winit = "0.28.4"
 image = "0.24.6"

--- a/build_wasm.sh
+++ b/build_wasm.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 rm -rf ./out/
 mkdir ./out
 rustup target add wasm32-unknown-unknown
-cargo build --release --target wasm32-unknown-unknown
+cargo build --release --target wasm32-unknown-unknown --features web
 cargo install wasm-bindgen-cli
 wasm-bindgen --out-dir ./out/ --target web --split-linked-modules ./target/wasm32-unknown-unknown/release/thetawave.wasm
 wasm-opt out/thetawave_bg.wasm -Oz -o thetawave_bg.wasm

--- a/crates/thetawave_interface/Cargo.toml
+++ b/crates/thetawave_interface/Cargo.toml
@@ -12,3 +12,4 @@ strum_macros = {workspace = true}
 derive_more = {workspace = true}
 bevy_ecs_macros = {workspace = true}
 bevy_ecs = {workspace = true}
+bevy_log = {workspace = true}

--- a/crates/thetawave_interface/src/assets.rs
+++ b/crates/thetawave_interface/src/assets.rs
@@ -1,0 +1,67 @@
+use bevy_ecs_macros::Resource;
+use bevy_log::error;
+use derive_more::{Deref, DerefMut, From};
+use std::default::Default;
+use std::env;
+use std::path::{Path, PathBuf};
+pub const BACKGROUND_ASSETS_BASE_PATH_ENV_VAR_NAME: &str = "THETAWAVE_BACKGROUND_ASSETS_PATH";
+/// A collection of file names/paths for individual background image assets to be lazily loaded.
+/// These are fit to be used with bevy's AssetServer::load. Many architectures will support
+/// bevy::asset::AssetIO::read_directory . But wasm32 does not support it. So we have a fallback
+/// that can be populated by other systems. Generally this will be written to once and never
+/// updated again.
+#[derive(Resource, Deref, DerefMut, Default, From)]
+pub struct BackupBackgroundAssetPaths(pub Vec<String>);
+
+impl BackupBackgroundAssetPaths {
+    /// Return the string names of files at the base path, relative to that base path.
+    pub fn from_local_base_path(base_path: &Path) -> Self {
+        let fnames = match std::fs::read_dir(base_path) {
+            Err(err) => {
+                error!(
+                    "Failed to read background asset base path. {} . Error: {}",
+                    base_path.to_string_lossy(),
+                    err
+                );
+                Default::default()
+            }
+            Ok(dir) => dir
+                .into_iter()
+                .filter_map(|path| match &path {
+                    Ok(path_) if path_.path().exists() => {
+                        Some(path_.path().into_os_string().to_string_lossy().into_owned())
+                    }
+                    Ok(_) => None,
+                    Err(err) => {
+                        error!(
+                            "Failed to read path {:?} base_path={}, Err: {}",
+                            &path,
+                            base_path.to_string_lossy(),
+                            err
+                        );
+                        None
+                    }
+                })
+                .collect::<Vec<String>>(),
+        };
+        fnames.into()
+    }
+    /// Return the string names of files at the base path (input as a string), relative to that base path.
+    pub fn from_raw_path(raw_path: String) -> Option<Self> {
+        Some(Self::from_local_base_path(&PathBuf::from(raw_path)))
+    }
+    pub fn from_env_and_local_fs() -> Option<Self> {
+        let raw_path = match env::var(BACKGROUND_ASSETS_BASE_PATH_ENV_VAR_NAME) {
+            Err(e) => {
+                error!(
+                        "Failed to read environment variable {}. This is ok if we are running in the browser. {}",
+                        BACKGROUND_ASSETS_BASE_PATH_ENV_VAR_NAME,
+                        e
+                    );
+                None
+            }
+            Ok(val) => Some(val),
+        }?;
+        Self::from_raw_path(raw_path)
+    }
+}

--- a/crates/thetawave_interface/src/lib.rs
+++ b/crates/thetawave_interface/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod assets;
 pub mod character_selection;
 pub mod game;
 pub mod health;

--- a/crates/thetawave_web/Cargo.toml
+++ b/crates/thetawave_web/Cargo.toml
@@ -9,15 +9,14 @@ edition = "2021"
 wasm-bindgen = { version = "0.2.74" }
 js-sys = "0.3.64"
 wasm-bindgen-futures = "0.4.37"
+console_error_panic_hook = "0.1.7"
 bevy_log = { workspace = true}
 bevy_app = { workspace = true}
 bevy_ecs = { workspace = true}
-bevy_tasks = { workspace = true}
 serde = { workspace = true}
 serde_derive = { workspace = true}
 serde-xml-rs = { workspace = true}
 derive_more = { workspace = true}
-futures-lite = { workspace = true}
 async-channel = { workspace = true}
 thetawave_interface = {path = "../thetawave_interface"}
 

--- a/crates/thetawave_web/Cargo.toml
+++ b/crates/thetawave_web/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "thetawave_web"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+wasm-bindgen = { version = "0.2.74" }
+js-sys = "0.3.64"
+wasm-bindgen-futures = "0.4.37"
+bevy_log = { workspace = true}
+bevy_app = { workspace = true}
+bevy_ecs = { workspace = true}
+bevy_tasks = { workspace = true}
+serde = { workspace = true}
+serde_derive = { workspace = true}
+serde-xml-rs = { workspace = true}
+derive_more = { workspace = true}
+futures-lite = { workspace = true}
+async-channel = { workspace = true}
+thetawave_interface = {path = "../thetawave_interface"}
+
+
+[dependencies.web-sys]
+version = "0.3.64"
+features = [
+  'AbortController',
+  'AbortSignal',
+  'Request',
+  'RequestInit',
+  'Response',
+  'Window',
+]

--- a/crates/thetawave_web/README.md
+++ b/crates/thetawave_web/README.md
@@ -1,0 +1,3 @@
+# Thetawave-web
+
+This crate includes Thetawave features/plugins that are specific to running in the browser.

--- a/crates/thetawave_web/src/fetch_url_with_timeout.js
+++ b/crates/thetawave_web/src/fetch_url_with_timeout.js
@@ -1,0 +1,31 @@
+/**
+ * Fetches data from the specified URL with a timeout. Prefers logging to throwing an error.
+ * @param {string} url - The URL to fetch data from.
+ * @param {number} timeoutMs - The timeout duration in milliseconds.
+ * @returns {Promise<string>} A Promise that resolves to the fetched data as a string.
+ */
+export async function fetchWithTimeout(url, timeoutMs) {
+  // Modeled after https://stackoverflow.com/a/50101022
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const response = await fetch(url, { signal: controller.signal });
+    clearTimeout(timeoutId);
+    console.log(response);
+    if (!response.ok) {
+      console.error(
+        `Network response was not ok: ${response.status} ${response.statusText}`,
+      );
+      return;
+    }
+    const res = await response.text();
+    return res;
+  } catch (err) {
+    if (err.name == "AbortError") {
+      console.error("Failed to download url in time.");
+      return;
+    }
+    console.error("Uncaught error fetching data js", err);
+  }
+}

--- a/crates/thetawave_web/src/lib.rs
+++ b/crates/thetawave_web/src/lib.rs
@@ -3,39 +3,11 @@ mod s3;
 
 use crate::public_s3_assets::PublicS3AssetsPlugin;
 use bevy_app::{App, Plugin, PluginGroup, PluginGroupBuilder};
-use bevy_log::{error, warn};
 use wasm_bindgen::prelude::{wasm_bindgen, JsValue};
 
 #[wasm_bindgen(module = "/src/fetch_url_with_timeout.js")]
 extern "C" {
     async fn fetchWithTimeout(url: String, timeoutMs: u32) -> JsValue;
-}
-
-fn get_filenames_from_s3_list_buckets_resp(s3_resp: s3::ListBucketV2Response) -> Vec<String> {
-    s3_resp.contents.iter().map(|x| x.key.clone()).collect()
-}
-
-/// If this returns an empty collection, then something is wrong (we would have logged it). And the
-/// game should just move on. S3 data should be _very_ optional.
-pub async fn raw_list_public_s3_bucket(url: &str, timeout_ms: u32) -> Vec<String> {
-    match fetchWithTimeout(String::from(url), timeout_ms)
-        .await
-        .as_string()
-    {
-        Some(str_result) => {
-            return serde_xml_rs::from_str::<s3::ListBucketV2Response>(&str_result)
-                .map(get_filenames_from_s3_list_buckets_resp)
-                .unwrap_or_else(|err| {
-                    error!("Failed to parse s3 list bucket response. Err: {}", err);
-                    error!("Bad S3 listBuckets response; {}", &str_result);
-                    Default::default()
-                });
-        }
-        None => {
-            warn!("Received no data from unsigned S3 List objects request.");
-        }
-    };
-    Default::default()
 }
 
 pub struct RedirectPanicsToBrowserConsoleLogPlugin;

--- a/crates/thetawave_web/src/lib.rs
+++ b/crates/thetawave_web/src/lib.rs
@@ -1,0 +1,36 @@
+pub mod public_s3_assets;
+mod s3;
+use bevy_log::{error, warn};
+use wasm_bindgen::prelude::{wasm_bindgen, JsValue};
+
+#[wasm_bindgen(module = "/src/fetch_url_with_timeout.js")]
+extern "C" {
+    async fn fetchWithTimeout(url: String, timeoutMs: u32) -> JsValue;
+}
+
+fn get_filenames_from_s3_list_buckets_resp(s3_resp: s3::ListBucketV2Response) -> Vec<String> {
+    s3_resp.contents.iter().map(|x| x.key.clone()).collect()
+}
+
+/// If this returns an empty collection, then something is wrong (we would have logged it). And the
+/// game should just move on. S3 data should be _very_ optional.
+pub async fn raw_list_public_s3_bucket(url: &str, timeout_ms: u32) -> Vec<String> {
+    match fetchWithTimeout(String::from(url), timeout_ms)
+        .await
+        .as_string()
+    {
+        Some(str_result) => {
+            return serde_xml_rs::from_str::<s3::ListBucketV2Response>(&str_result)
+                .map(get_filenames_from_s3_list_buckets_resp)
+                .unwrap_or_else(|err| {
+                    error!("Failed to parse s3 list bucket response. Err: {}", err);
+                    error!("Bad S3 listBuckets response; {}", str_result);
+                    Default::default()
+                });
+        }
+        None => {
+            warn!("Received no data from unsigned S3 List objects request.");
+        }
+    };
+    Default::default()
+}

--- a/crates/thetawave_web/src/lib.rs
+++ b/crates/thetawave_web/src/lib.rs
@@ -1,5 +1,8 @@
 pub mod public_s3_assets;
 mod s3;
+
+use crate::public_s3_assets::PublicS3AssetsPlugin;
+use bevy_app::{App, Plugin, PluginGroup, PluginGroupBuilder};
 use bevy_log::{error, warn};
 use wasm_bindgen::prelude::{wasm_bindgen, JsValue};
 
@@ -24,7 +27,7 @@ pub async fn raw_list_public_s3_bucket(url: &str, timeout_ms: u32) -> Vec<String
                 .map(get_filenames_from_s3_list_buckets_resp)
                 .unwrap_or_else(|err| {
                     error!("Failed to parse s3 list bucket response. Err: {}", err);
-                    error!("Bad S3 listBuckets response; {}", str_result);
+                    error!("Bad S3 listBuckets response; {}", &str_result);
                     Default::default()
                 });
         }
@@ -33,4 +36,19 @@ pub async fn raw_list_public_s3_bucket(url: &str, timeout_ms: u32) -> Vec<String
         }
     };
     Default::default()
+}
+
+pub struct RedirectPanicsToBrowserConsoleLogPlugin;
+impl Plugin for RedirectPanicsToBrowserConsoleLogPlugin {
+    fn build(&self, _app: &mut App) {
+        std::panic::set_hook(Box::new(console_error_panic_hook::hook));
+    }
+}
+
+pub struct WebWasmSpecificPlugins;
+impl PluginGroup for WebWasmSpecificPlugins {
+    fn build(self) -> PluginGroupBuilder {
+        self.set(RedirectPanicsToBrowserConsoleLogPlugin)
+            .set(PublicS3AssetsPlugin)
+    }
 }

--- a/crates/thetawave_web/src/public_s3_assets.rs
+++ b/crates/thetawave_web/src/public_s3_assets.rs
@@ -1,0 +1,87 @@
+use super::raw_list_public_s3_bucket;
+use async_channel::{bounded, Receiver, Sender};
+use bevy_app::{App, FixedUpdate, Plugin};
+use bevy_ecs::prelude::{in_state, Condition, IntoSystemConfigs, OnEnter, Resource};
+use bevy_ecs::system::{Res, ResMut};
+use bevy_log::{error, info};
+use derive_more::{Deref, DerefMut, From};
+use thetawave_interface::assets::BackupBackgroundAssetPaths;
+use thetawave_interface::states::AppStates;
+use wasm_bindgen_futures::spawn_local;
+
+/// Since Bevy doesn't handle async things so well (each system function ultimately blocks the next
+/// frame), we spawn a single-element queue with these ends, then populate a resource as part of
+/// the public API used by other plugins.
+#[derive(Resource, Deref, DerefMut, From)]
+struct FetchS3FileNamesTask(Receiver<Vec<String>>);
+
+#[derive(Resource, Deref, DerefMut, Clone, From)]
+struct DownloadedS3FileNamesChannelInput(Sender<Vec<String>>);
+
+#[derive(Resource, Debug, Clone)]
+pub struct RemoteAssetFetchOptions {
+    /// The base URL of the S3-compatible bucket/service that can support ListBucketV2 requests.
+    pub s3_bucket_base_url: String,
+    pub timeout_ms: u32,
+}
+/// Populates `BackupBackgroundAssetPaths` with strings that can be sent to
+/// `bevy_asset::AssetServer::load`. These will use an S3-compatible service behind some CDN+DNS
+/// magic external to the program. This plugin has to assume some amount about the deployment
+/// environment and how the S3+AssetServer routing works.
+pub struct PublicS3AssetsPlugin;
+
+fn start_listing_s3_files(
+    remote_asset_options: Res<RemoteAssetFetchOptions>,
+    got_s3_filenames_sender: Res<DownloadedS3FileNamesChannelInput>,
+) {
+    info!("Starting to list the s3 remote assets");
+    let RemoteAssetFetchOptions {
+        s3_bucket_base_url,
+        timeout_ms,
+        ..
+    } = remote_asset_options.clone();
+    let tx = (*got_s3_filenames_sender).clone();
+    spawn_local(async move {
+        let free_background_assets_url = s3_bucket_base_url + "?prefix=free_assets/backgrounds";
+        let got_fnames =
+            raw_list_public_s3_bucket(free_background_assets_url.as_ref(), timeout_ms).await;
+        info!("Downloaded S3 filenames. Putting then on the queue");
+        tx.try_send(got_fnames).unwrap_or_else(|_| {
+            error!("Queue full. too many HTTP requests");
+        });
+        tx.close();
+    });
+}
+/// We don't have an event loop right now in the game, so we have no choice but to poll.
+fn poll_for_complete_s3_list_background_assets_and_populate_cache_if_compolete(
+    downloaded_s3_filenames: Res<FetchS3FileNamesTask>,
+    mut cached_background_asset_paths: ResMut<BackupBackgroundAssetPaths>,
+) {
+    if let Ok(file_names) = (*downloaded_s3_filenames).try_recv() {
+        info!(
+            "Retrieved {} background assets paths from S3. Found: {:?}",
+            &file_names.len(),
+            &file_names
+        );
+        **cached_background_asset_paths = file_names;
+        downloaded_s3_filenames.close(); // We should only need to do this once.
+    }
+}
+impl Plugin for PublicS3AssetsPlugin {
+    fn build(&self, app: &mut App) {
+        let (tx, rx) = bounded::<Vec<String>>(1);
+        app.insert_resource(DownloadedS3FileNamesChannelInput::from(tx))
+            .insert_resource(FetchS3FileNamesTask::from(rx))
+            .insert_resource(RemoteAssetFetchOptions {
+                s3_bucket_base_url: "https://assets.thetawave.metalmancy.tech".to_string(),
+                timeout_ms: 2000,
+            })
+            .add_systems(OnEnter(AppStates::LoadingAssets), start_listing_s3_files)
+            .add_systems(
+                FixedUpdate,
+                poll_for_complete_s3_list_background_assets_and_populate_cache_if_compolete.run_if(
+                    in_state(AppStates::MainMenu).or_else(in_state(AppStates::LoadingAssets)),
+                ),
+            );
+    }
+}

--- a/crates/thetawave_web/src/s3.rs
+++ b/crates/thetawave_web/src/s3.rs
@@ -1,0 +1,29 @@
+//! Minimal parsing for a few S3 requests. Very much not feature complete, to keep the wasm binary small. Many keys are
+//! missing from the objects, keeping things close to what we need for the game. We might eventually use
+//! https://github.com/awslabs/aws-sdk-rust
+use serde::Deserialize;
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct ListBucketV2Response {
+    pub name: String,
+    pub prefix: Option<String>,
+    pub delimiter: Option<String>,
+    pub max_keys: Option<u32>,
+    pub is_truncated: bool,
+    pub contents: Vec<Object>,
+    pub common_prefixes: Option<Vec<CommonPrefix>>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct Object {
+    pub key: String,
+    pub last_modified: String,
+    pub size: u64,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct CommonPrefix {
+    pub prefix: String,
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -95,16 +95,7 @@ fn get_display_config() -> options::DisplayConfig {
     }
 }
 
-#[allow(dead_code)]
-fn setup_panic() {
-    use std::panic;
-    panic::set_hook(Box::new(console_error_panic_hook::hook)); // pushes rust errors to the browser console
-}
-
 fn main() {
-    #[cfg(target_arch = "wasm32")]
-    setup_panic();
-
     let display_config = get_display_config();
 
     let mut app = App::new();
@@ -143,6 +134,7 @@ fn main() {
         color: Color::WHITE,
         brightness: 0.1,
     })
+    .insert_resource(thetawave_interface::assets::BackupBackgroundAssetPaths::default())
     .add_plugins(AudioPlugin)
     .add_plugins(RapierPhysicsPlugin::<NoUserData>::pixels_per_meter(
         PHYSICS_SCALE,
@@ -157,6 +149,9 @@ fn main() {
 
     #[cfg(feature = "storage")]
     app.add_plugins(thetawave_storage::plugin::DBPlugin);
+
+    #[cfg(all(target_arch = "wasm32", feature = "web"))]
+    app.add_plugins(thetawave_web::WebWasmSpecificPlugins);
 
     if cfg!(debug_assertions) {
         app


### PR DESCRIPTION
The only thing @cdsupina needs to use is 
```rust
/// A collection of file names/paths for individual background image assets to be lazily loaded.
/// These are fit to be used with bevy's AssetServer::load. Many architectures will support
/// bevy::asset::AssetIO::read_directory . But wasm32 does not support it. So we have a fallback
/// that can be populated by other systems. Generally this will be written to once and never
/// updated again.
#[derive(Resource, Deref, DerefMut, Default, From)]
pub struct BackupBackgroundAssetPaths(pub Vec<String>);
```