### PR TITLE
Infer the arduino arcade serial port from available ports, falling back to an envvar

### DIFF
--- a/crates/thetawave_arcade/Cargo.toml
+++ b/crates/thetawave_arcade/Cargo.toml
@@ -10,3 +10,5 @@ bevy_serialport = {version = "0.4.0"}
 bytes = "1.4.0"
 bevy = {workspace = true}
 thetawave_interface = {path = "../thetawave_interface"}
+derive_more = {workspace = true}
+serialport = { version = "4" }

--- a/crates/thetawave_arcade/README.md
+++ b/crates/thetawave_arcade/README.md
@@ -1,0 +1,9 @@
+# Thetawave-arcade
+
+This crate exposes Bevy plugins that implement features specific to the arcade cabinet build target/platform.
+
+
+## Configuration
+
+- `THETAWAVE_ARCADE_LIGHT_SERIAL_PORT_NAME` = The name of the serial port that controls the lights. We will probably
+  automate detecting this later, but this is currently related to a port used by Arduino.

--- a/crates/thetawave_arcade/src/arduino.rs
+++ b/crates/thetawave_arcade/src/arduino.rs
@@ -26,6 +26,8 @@ impl ArduinoSerialPort {
     }
 }
 
+/// Find a serial port from all available ports where the manufacturer or product match a string
+/// pattern.
 fn first_usb_port_name_matching_str(lowercase_pattern: &str) -> Option<String> {
     match available_ports() {
         Ok(ports) => ports
@@ -49,10 +51,11 @@ fn first_usb_port_name_matching_str(lowercase_pattern: &str) -> Option<String> {
 use bytes::Bytes;
 use thetawave_interface::character_selection::PlayerJoinEvent;
 
-/// The entrypoint for accepting game input from an arcade machine.
-pub struct ArcadePlugin;
+/// Features specific to an Arduino that is only running on custom-made arcade machines. Mostly
+/// lighting. The plugin no-ops if an Arduino serial port cannot be accessed.
+pub struct ArcadeArduinoPlugin;
 
-impl Plugin for ArcadePlugin {
+impl Plugin for ArcadeArduinoPlugin {
     fn build(&self, app: &mut App) {
         if let Some(res) = ArduinoSerialPort::first_port_matching_manufacturer_product()
             .or_else(ArduinoSerialPort::from_envvar)

--- a/crates/thetawave_arcade/src/arduino.rs
+++ b/crates/thetawave_arcade/src/arduino.rs
@@ -9,12 +9,12 @@ use serialport::{available_ports, SerialPortType};
 use thetawave_interface::states;
 
 /// Environment variable name of the serial port that handles lights.
-pub const THETAWAVE_ARCADE_LIGHT_SERIAL_PORT_NAME: &'static str =
+const THETAWAVE_ARCADE_LIGHT_SERIAL_PORT_NAME: &'static str =
     "THETAWAVE_ARCADE_LIGHT_SERIAL_PORT_NAME";
 
 /// The port for the Arduino that controls the lights.
 #[derive(Resource, Deref, DerefMut, From, Debug)]
-pub struct ArduinoSerialPort(String);
+struct ArduinoSerialPort(String);
 impl ArduinoSerialPort {
     fn first_port_matching_manufacturer_product() -> Option<Self> {
         first_usb_port_name_matching_str("arduino").map(Self)

--- a/crates/thetawave_arcade/src/lib.rs
+++ b/crates/thetawave_arcade/src/lib.rs
@@ -1,2 +1,2 @@
 /// Exposes a single Bevy plugin for integrating the arcade IO into the game systems.
-pub mod plugin;
+pub mod arduino;

--- a/crates/thetawave_arcade/src/plugin.rs
+++ b/crates/thetawave_arcade/src/plugin.rs
@@ -4,8 +4,48 @@ use bevy_serialport::{
     SerialResource, StopBits,
 };
 
+use derive_more::{Deref, DerefMut, From};
+use serialport::{available_ports, SerialPortType};
 use thetawave_interface::states;
 
+/// Environment variable name of the serial port that handles lights.
+pub const THETAWAVE_ARCADE_LIGHT_SERIAL_PORT_NAME: &'static str =
+    "THETAWAVE_ARCADE_LIGHT_SERIAL_PORT_NAME";
+
+/// The port for the Arduino that controls the lights.
+#[derive(Resource, Deref, DerefMut, From, Debug)]
+pub struct ArduinoSerialPort(String);
+impl ArduinoSerialPort {
+    fn first_port_matching_manufacturer_product() -> Option<Self> {
+        first_usb_port_name_matching_str("arduino").map(Self)
+    }
+    fn from_envvar() -> Option<Self> {
+        std::env::var(THETAWAVE_ARCADE_LIGHT_SERIAL_PORT_NAME)
+            .ok()
+            .map(Self)
+    }
+}
+
+fn first_usb_port_name_matching_str(lowercase_pattern: &str) -> Option<String> {
+    match available_ports() {
+        Ok(ports) => ports
+            .into_iter()
+            .find(|x| match &x.port_type {
+                SerialPortType::UsbPort(x) => format!(
+                    "{} {}",
+                    x.manufacturer.clone().unwrap_or_default().to_lowercase(),
+                    x.product.clone().unwrap_or_default().to_lowercase()
+                )
+                .contains(lowercase_pattern),
+                _ => false,
+            })
+            .map(|x| x.port_name.clone()),
+        Err(e) => {
+            error!("Failed to list serial ports. {}", e);
+            None
+        }
+    }
+}
 use bytes::Bytes;
 use thetawave_interface::character_selection::PlayerJoinEvent;
 
@@ -14,61 +54,69 @@ pub struct ArcadePlugin;
 
 impl Plugin for ArcadePlugin {
     fn build(&self, app: &mut App) {
-        app.add_plugins(SerialPortPlugin);
+        if let Some(res) = ArduinoSerialPort::first_port_matching_manufacturer_product()
+            .or_else(ArduinoSerialPort::from_envvar)
+        {
+            info!("arduino serial port: {:?}", &res);
+            app.add_plugins(SerialPortPlugin).insert_resource(res);
 
-        app.add_systems(
-            Startup,
-            (setup_serial_system, enter_main_menu_button_leds_system),
-        );
+            app.add_systems(
+                Startup,
+                (setup_serial_system, enter_main_menu_button_leds_system),
+            );
 
-        app.add_systems(
-            OnEnter(states::AppStates::MainMenu),
-            enter_main_menu_button_leds_system,
-        );
+            app.add_systems(
+                OnEnter(states::AppStates::MainMenu),
+                enter_main_menu_button_leds_system,
+            );
 
-        app.add_systems(
-            OnEnter(states::AppStates::CharacterSelection),
-            enter_character_selection_button_leds_system,
-        );
+            app.add_systems(
+                OnEnter(states::AppStates::CharacterSelection),
+                enter_character_selection_button_leds_system,
+            );
 
-        app.add_systems(
-            Update,
-            character_selection_button_leds_system
-                .run_if(in_state(states::AppStates::CharacterSelection)),
-        );
+            app.add_systems(
+                Update,
+                character_selection_button_leds_system
+                    .run_if(in_state(states::AppStates::CharacterSelection)),
+            );
 
-        app.add_systems(
-            OnEnter(thetawave_interface::states::AppStates::Game),
-            enter_game_button_leds_system,
-        );
+            app.add_systems(
+                OnEnter(thetawave_interface::states::AppStates::Game),
+                enter_game_button_leds_system,
+            );
 
-        app.add_systems(
-            OnEnter(states::GameStates::Paused),
-            enter_pause_button_leds_system,
-        );
+            app.add_systems(
+                OnEnter(states::GameStates::Paused),
+                enter_pause_button_leds_system,
+            );
 
-        app.add_systems(
-            OnExit(states::GameStates::Paused),
-            enter_game_button_leds_system,
-        );
+            app.add_systems(
+                OnExit(states::GameStates::Paused),
+                enter_game_button_leds_system,
+            );
 
-        app.add_systems(
-            OnEnter(states::AppStates::Victory),
-            enter_victory_button_leds_system,
-        );
+            app.add_systems(
+                OnEnter(states::AppStates::Victory),
+                enter_victory_button_leds_system,
+            );
 
-        app.add_systems(
-            OnEnter(states::AppStates::GameOver),
-            enter_gameover_button_leds_system,
-        );
+            app.add_systems(
+                OnEnter(states::AppStates::GameOver),
+                enter_gameover_button_leds_system,
+            );
+        } else {
+            error!("Failed to find the arduino port for arcade lighting. no-op for the plugin. Enter the environment variable {} or compile without the --arcade feature", THETAWAVE_ARCADE_LIGHT_SERIAL_PORT_NAME);
+        }
     }
 }
 fn setup_serial_system(
     mut serial_resource: ResMut<SerialResource>,
+    arduino_port: Res<ArduinoSerialPort>,
     runtime: Res<SerialPortRuntime>,
 ) {
     let serial_setting = SerialPortSetting {
-        port_name: "COM3".to_string(),
+        port_name: arduino_port.clone(),
         baud_rate: 115200,
         data_bits: DataBits::Eight,
         flow_control: FlowControl::None,
@@ -76,10 +124,9 @@ fn setup_serial_system(
         stop_bits: StopBits::One,
         timeout: Default::default(),
     };
-
     serial_resource
         .open_with_setting(runtime.clone(), serial_setting)
-        .expect("Error opening serial port");
+        .expect(&format!("Error opening serial port {:?}", &arduino_port));
 }
 
 enum ButtonLEDByte {
@@ -187,39 +234,58 @@ impl ButtonLEDByte {
     }
 }
 
-fn enter_main_menu_button_leds_system(mut serial_resource: ResMut<SerialResource>) {
-    serial_resource.send_message("COM3", ButtonLEDByte::enter_main_menu());
+fn enter_main_menu_button_leds_system(
+    mut serial_resource: ResMut<SerialResource>,
+    arduino_port: Res<ArduinoSerialPort>,
+) {
+    serial_resource.send_message(&(*arduino_port), ButtonLEDByte::enter_main_menu());
 }
 
-fn enter_character_selection_button_leds_system(mut serial_resource: ResMut<SerialResource>) {
-    serial_resource.send_message("COM3", ButtonLEDByte::enter_character_selection());
+fn enter_character_selection_button_leds_system(
+    mut serial_resource: ResMut<SerialResource>,
+    arduino_port: Res<ArduinoSerialPort>,
+) {
+    serial_resource.send_message(&(*arduino_port), ButtonLEDByte::enter_character_selection());
 }
 
 fn character_selection_button_leds_system(
     mut serial_resource: ResMut<SerialResource>,
+    arduino_port: Res<ArduinoSerialPort>,
     mut player_join_event: EventReader<PlayerJoinEvent>,
 ) {
     for event in player_join_event.iter() {
         if event.0 == 0 {
-            serial_resource.send_message("COM3", ButtonLEDByte::player_one_joined());
+            serial_resource.send_message(&(*arduino_port), ButtonLEDByte::player_one_joined());
         } else if event.0 == 1 {
-            serial_resource.send_message("COM3", ButtonLEDByte::player_two_joined());
+            serial_resource.send_message(&(*arduino_port), ButtonLEDByte::player_two_joined());
         }
     }
 }
 
-fn enter_game_button_leds_system(mut serial_resource: ResMut<SerialResource>) {
-    serial_resource.send_message("COM3", ButtonLEDByte::enter_game());
+fn enter_game_button_leds_system(
+    mut serial_resource: ResMut<SerialResource>,
+    arduino_port: Res<ArduinoSerialPort>,
+) {
+    serial_resource.send_message(&(*arduino_port), ButtonLEDByte::enter_game());
 }
 
-fn enter_pause_button_leds_system(mut serial_resource: ResMut<SerialResource>) {
-    serial_resource.send_message("COM3", ButtonLEDByte::enter_pause());
+fn enter_pause_button_leds_system(
+    mut serial_resource: ResMut<SerialResource>,
+    arduino_port: Res<ArduinoSerialPort>,
+) {
+    serial_resource.send_message(&(*arduino_port), ButtonLEDByte::enter_pause());
 }
 
-fn enter_gameover_button_leds_system(mut serial_resource: ResMut<SerialResource>) {
-    serial_resource.send_message("COM3", ButtonLEDByte::enter_gameover());
+fn enter_gameover_button_leds_system(
+    mut serial_resource: ResMut<SerialResource>,
+    arduino_port: Res<ArduinoSerialPort>,
+) {
+    serial_resource.send_message(&(*arduino_port), ButtonLEDByte::enter_gameover());
 }
 
-fn enter_victory_button_leds_system(mut serial_resource: ResMut<SerialResource>) {
-    serial_resource.send_message("COM3", ButtonLEDByte::enter_victory());
+fn enter_victory_button_leds_system(
+    mut serial_resource: ResMut<SerialResource>,
+    arduino_port: Res<ArduinoSerialPort>,
+) {
+    serial_resource.send_message(&(*arduino_port), ButtonLEDByte::enter_victory());
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -183,7 +183,7 @@ impl PluginGroup for ThetawaveGamePlugins {
         // TODO: Remove this "not(test)" in a subsequent PR when that plugin removes an unwrap.
         #[cfg(all(feature = "arcade", not(test)))]
         {
-            res = res.add(thetawave_arcade::plugin::ArcadePlugin);
+            res = res.add(thetawave_arcade::arduino::ArcadeArduinoPlugin);
         }
         #[cfg(feature = "storage")]
         {

--- a/src/main.rs
+++ b/src/main.rs
@@ -180,8 +180,7 @@ impl PluginGroup for ThetawaveGamePlugins {
             .add(ui::UiPlugin)
             .add(options::OptionsPlugin)
             .add(audio::ThetawaveAudioPlugin);
-        // TODO: Remove this "not(test)" in a subsequent PR when that plugin removes an unwrap.
-        #[cfg(all(feature = "arcade", not(test)))]
+        #[cfg(feature = "arcade")]
         {
             res = res.add(thetawave_arcade::arduino::ArcadeArduinoPlugin);
         }


### PR DESCRIPTION
We need to automate detecting this later or hoist this further to a CLI, but this is better than what we have right now. I _think_ we will use a CLI with `argh` or `clap` to do some config options. #91 also uses a similar type of config option. 

E.x. `THETAWAVE_ARCADE_LIGHT_SERIAL_PORT_NAME=/dev/tty4 ./thetawave`

This is all so that you don't need to edit the source code on arcade machine/ensures that we can deploy the exact code that we test. 