### PR TITLE
Smoke test as much of the game as possible

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+use bevy::app::PluginGroupBuilder;
 use bevy::{pbr::AmbientLight, prelude::*};
 use bevy_kira_audio::prelude::*;
 
@@ -105,64 +106,43 @@ fn main() {
 
     let display_config = get_display_config();
 
-    let mut app = App::new();
-
-    app.add_state::<AppStates>(); // start game in the main menu state
-    app.add_state::<GameStates>(); // start the game in playing state
-
-    // insert resources for all game states
-    app.add_plugins(
+    let mut app = build_app(
         DefaultPlugins
             .set(WindowPlugin {
                 primary_window: Some(Window::from(display_config)),
                 ..default()
             })
             .set(ImagePlugin::default_nearest()),
-    )
-    .add_plugins(player::PlayerPlugin)
-    .add_plugins(spawnable::SpawnablePlugin)
-    .add_plugins(run::RunPlugin)
-    .add_plugins(loot::LootPlugin)
-    .add_plugins(game::GamePlugin)
-    .add_plugins(background::BackgroundPlugin)
-    .add_plugins(audio::ThetawaveAudioPlugin)
-    .add_plugins(options::OptionsPlugin)
-    .add_plugins(camera::CameraPlugin)
-    .add_plugins(ui::UiPlugin)
-    .add_plugins(arena::ArenaPlugin)
-    .add_plugins(collision::CollisionPlugin)
-    .add_plugins(scanner::ScannerPlugin)
-    .add_plugins(animation::AnimationPlugin)
-    .add_plugins(states::StatesPlugin)
-    .add_plugins(game::counters::plugin::CountingMetricsPlugin)
-    .add_plugins(misc::HealthPlugin)
-    .insert_resource(ClearColor(Color::BLACK))
-    .insert_resource(AmbientLight {
-        color: Color::WHITE,
-        brightness: 0.1,
-    })
-    .add_plugins(AudioPlugin)
-    .add_plugins(RapierPhysicsPlugin::<NoUserData>::pixels_per_meter(
-        PHYSICS_SCALE,
-    ));
+        ThetawaveGamePlugins,
+    );
+
+    app.run();
+}
+
+/// Make the runnable platform-specific app. `base_plugins` describes "external dependencies"
+/// outside the scope of the game itself. These typically come from `bevy::MinimalPlugins` or
+/// `bevy::DefaultPlugins`. `game_plugins` comes from from `ThetawaveGamePlugins`.
+fn build_app<P1: PluginGroup, P2: PluginGroup>(base_plugins: P1, game_plugins: P2) -> App {
+    // Should everything besides adding the plugins be moved into a plugin?
+    let mut app = App::new();
+    app.add_state::<AppStates>() // start game in the main menu state
+        .add_state::<GameStates>(); // start the game in playing state
+    app.add_plugins(base_plugins);
+    app.add_plugins(game_plugins);
+    app.insert_resource(ClearColor(Color::BLACK))
+        .insert_resource(AmbientLight {
+            color: Color::WHITE,
+            brightness: 0.1,
+        });
 
     app.add_systems(
         OnEnter(AppStates::Game),
         setup_physics.in_set(GameEnterSet::Initialize),
     );
-    #[cfg(feature = "arcade")]
-    app.add_plugins(thetawave_arcade::plugin::ArcadePlugin);
-
-    #[cfg(feature = "storage")]
-    app.add_plugins(thetawave_storage::plugin::DBPlugin);
-
-    if cfg!(debug_assertions) {
-        app
-            //.add_plugin(EditorPlugin::new())
-            .add_plugins(RapierDebugRenderPlugin::default());
+    if cfg!(debug_assertions) && !cfg!(test) {
+        app.add_plugins(RapierDebugRenderPlugin::default());
     }
-
-    app.run();
+    app
 }
 
 // setup rapier
@@ -170,4 +150,109 @@ fn setup_physics(mut rapier_config: ResMut<RapierConfiguration>) {
     rapier_config.physics_pipeline_active = true;
     rapier_config.query_pipeline_active = true;
     rapier_config.gravity = Vec2::ZERO;
+}
+/// This is the main collection of features and behaviors that define thetawave. 99% of the total
+/// behavior of all executables comes from this and Bevy plugins. Ideally 100% of the functionality
+/// of all Thetawave executables comes from this and Bevy plugins.
+pub struct ThetawaveGamePlugins;
+impl PluginGroup for ThetawaveGamePlugins {
+    fn build(self) -> PluginGroupBuilder {
+        #[allow(unused_mut)] // Allow because we might add more platform-specific features
+        let mut res = PluginGroupBuilder::start::<Self>()
+            .add(player::PlayerPlugin)
+            .add(spawnable::SpawnablePlugin)
+            .add(run::RunPlugin)
+            .add(loot::LootPlugin)
+            .add(game::GamePlugin)
+            .add(background::BackgroundPlugin)
+            .add(AudioPlugin)
+            .add(camera::CameraPlugin)
+            .add(arena::ArenaPlugin)
+            .add(collision::CollisionPlugin)
+            .add(scanner::ScannerPlugin)
+            .add(animation::AnimationPlugin)
+            .add(states::StatesPlugin)
+            .add(game::counters::plugin::CountingMetricsPlugin)
+            .add(misc::HealthPlugin)
+            .add(RapierPhysicsPlugin::<NoUserData>::pixels_per_meter(
+                PHYSICS_SCALE,
+            ))
+            .add(ui::UiPlugin)
+            .add(options::OptionsPlugin)
+            .add(audio::ThetawaveAudioPlugin);
+        // TODO: Remove this "not(test)" in a subsequent PR when that plugin removes an unwrap.
+        #[cfg(all(feature = "arcade", not(test)))]
+        {
+            res = res.add(thetawave_arcade::plugin::ArcadePlugin);
+        }
+        #[cfg(feature = "storage")]
+        {
+            res = res.add(thetawave_storage::plugin::DBPlugin);
+        }
+
+        res
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::audio::ThetawaveAudioPlugin;
+    use crate::{build_app, options, ui, ThetawaveGamePlugins};
+    use bevy::app::{App, PluginGroup};
+    use bevy::asset::AssetPlugin;
+    use bevy::input::InputPlugin;
+    use bevy::prelude::{ImagePlugin, NextState, State};
+    use bevy::MinimalPlugins;
+    use bevy_kira_audio::AudioPlugin;
+    use thetawave_interface::audio::{ChangeBackgroundMusicEvent, PlaySoundEffectEvent};
+    use thetawave_interface::states::AppStates;
+
+    #[test]
+    fn test_minimal_headless_audioless_game_gets_to_main_menu() {
+        // This atleast tests that many resourses/events required by systems have already been
+        // inserted, that many assets can be loaded, and that the game can kinda start.
+        let mut app = minimal_headless_audioless_app_with_as_many_game_features_as_possible();
+        app.update();
+        app.world
+            .get_resource_mut::<NextState<AppStates>>()
+            .unwrap()
+            .set(AppStates::LoadingAssets);
+        for _ in 0..10 {
+            // just update a few times. Not so important how many.
+            app.update();
+        }
+        app.world
+            .get_resource_mut::<NextState<AppStates>>()
+            .unwrap()
+            .set(AppStates::MainMenu);
+        app.update();
+        app.update();
+        assert_eq!(
+            app.world.get_resource::<State<AppStates>>().unwrap().get(),
+            &AppStates::MainMenu
+        );
+    }
+
+    fn minimal_headless_audioless_app_with_as_many_game_features_as_possible() -> App {
+        let base_plugins = MinimalPlugins
+            .build()
+            .add(AssetPlugin::default())
+            .add(ImagePlugin::default())
+            .add(InputPlugin::default());
+        // These features are basically untestable.
+        let game_plugins = ThetawaveGamePlugins
+            .build()
+            // Windowing/display/UI stuff is hard to test and we dont have a screen in CI.
+            .disable::<ui::UiPlugin>()
+            .disable::<options::OptionsPlugin>()
+            // Ideally audio is mostly handled via `thetawave_interface::audio` and events, so that
+            // we really only skip testing 1 match statement and external audio deps.
+            .disable::<ThetawaveAudioPlugin>()
+            .disable::<AudioPlugin>();
+
+        let mut app = build_app(base_plugins, game_plugins);
+        app.add_event::<ChangeBackgroundMusicEvent>()
+            .add_event::<PlaySoundEffectEvent>();
+        app
+    }
 }

--- a/src/states/game.rs
+++ b/src/states/game.rs
@@ -1,8 +1,8 @@
 use bevy::{app::AppExit, prelude::*};
-use bevy_kira_audio::prelude::*;
+use thetawave_interface::audio::{PlaySoundEffectEvent, SoundEffectType};
 use thetawave_interface::states::AppStates;
 
-use crate::{audio, player::PlayersResource};
+use crate::player::PlayersResource;
 
 // Start the game by entering the Game state
 pub fn start_game_system(
@@ -11,8 +11,7 @@ pub fn start_game_system(
     mut keyboard_input: ResMut<Input<KeyCode>>,
     mut next_app_state: ResMut<NextState<AppStates>>,
     players_resource: Res<PlayersResource>,
-    asset_server: Res<AssetServer>,
-    audio_channel: Res<AudioChannel<audio::MenuAudioChannel>>,
+    mut sound_effect_pub: EventWriter<PlaySoundEffectEvent>,
 ) {
     // check for keyboard or gamepad input
     let mut start_input = keyboard_input.just_released(KeyCode::Return)
@@ -31,7 +30,9 @@ pub fn start_game_system(
         next_app_state.set(AppStates::InitializeRun);
 
         // play sound effect
-        audio_channel.play(asset_server.load("sounds/menu_input_success.wav"));
+        sound_effect_pub.send(PlaySoundEffectEvent {
+            sound_effect_type: SoundEffectType::MenuInputSuccess,
+        });
 
         // reset input
         keyboard_input.reset(KeyCode::Return);
@@ -52,8 +53,7 @@ pub fn start_instructions_system(
     mut gamepad_input: ResMut<Input<GamepadButton>>,
     mut keyboard_input: ResMut<Input<KeyCode>>,
     mut next_app_state: ResMut<NextState<AppStates>>,
-    asset_server: Res<AssetServer>,
-    audio_channel: Res<AudioChannel<audio::MenuAudioChannel>>,
+    mut sound_effect_pub: EventWriter<PlaySoundEffectEvent>,
 ) {
     // check for keyboard or gamepad input
     let mut start_input = keyboard_input.just_released(KeyCode::Return)
@@ -71,8 +71,9 @@ pub fn start_instructions_system(
         // set the state to game
         next_app_state.set(AppStates::Instructions);
 
-        // play sound effect
-        audio_channel.play(asset_server.load("sounds/menu_input_success.wav"));
+        sound_effect_pub.send(PlaySoundEffectEvent {
+            sound_effect_type: SoundEffectType::MenuInputSuccess,
+        });
 
         // reset input
         keyboard_input.reset(KeyCode::Return);
@@ -92,8 +93,7 @@ pub fn start_character_selection_system(
     mut gamepad_input: ResMut<Input<GamepadButton>>,
     mut keyboard_input: ResMut<Input<KeyCode>>,
     mut next_app_state: ResMut<NextState<AppStates>>,
-    asset_server: Res<AssetServer>,
-    audio_channel: Res<AudioChannel<audio::MenuAudioChannel>>,
+    mut sound_effect_pub: EventWriter<PlaySoundEffectEvent>,
 ) {
     // check for keyboard or gamepad input
     let mut start_input = keyboard_input.just_released(KeyCode::Return)
@@ -111,8 +111,9 @@ pub fn start_character_selection_system(
         // set the state to game
         next_app_state.set(AppStates::CharacterSelection);
 
-        // play sound effect
-        audio_channel.play(asset_server.load("sounds/menu_input_success.wav"));
+        sound_effect_pub.send(PlaySoundEffectEvent {
+            sound_effect_type: SoundEffectType::MenuInputSuccess,
+        });
 
         // reset input
         keyboard_input.reset(KeyCode::Return);


### PR DESCRIPTION
I want to merge this before #93 . Adds a smoke test to verify that we can atleast get to the main menu and the app can launch. This doesnt test _much_ but it tests more than nothing.

Using `cargo tarpaulin --workspace --all-features`

On [2709b75](https://github.com/thetawavegame/thetawave/pull/106/commits/2709b751d56372ccefbdba49147d02bbe5867b26)

```
12.23% coverage, 274/2240 lines covered
```
On main :
```
37.50% coverage, 183/488 lines covered
```
Tarpaulin is not correct with the denominator, I think. But I am confident that this is a reasonable smoke test of a fair amount of the asset loading, ron file parsing, and that resources+events are inserted as needed, atleast through to the main menu.
Closes #65 