### PR TITLE
Add a CLI behind a compile time feature flag to accept the asset directory path

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,10 +20,14 @@ derive_more = "0.99.17"
 bevy_ecs_macros = "0.11.2"
 bevy_ecs = "0.11.2"
 bevy_kira_audio = { version = "0.16.0", features = ["mp3", "wav"] }
+# We value minimizing the binary sizes and keeping the CLI maximally simple over a more feature complete CLI library
+# like clap.
+argh = "0.1.12"
 
 
 [dev-dependencies]
 rstest = "0.18.2"
+assert_cmd = "2.0.12"
 
 [dependencies]
 bevy = { workspace = true }
@@ -55,6 +59,7 @@ thetawave_interface = { path = "crates/thetawave_interface" }
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 thetawave_storage = { path = "crates/thetawave_storage", optional = true }
 thetawave_arcade = { path = "crates/thetawave_arcade", optional = true }
+argh = { workspace = true, optional = true}
 
 
 # optimize dev packages as we don't need them in debug version
@@ -71,3 +76,4 @@ codegen-units = 1
 [features]
 arcade = ["thetawave_arcade"]
 storage = ["thetawave_storage"]
+cli = ["argh"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use bevy::app::PluginGroupBuilder;
-use bevy::{pbr::AmbientLight, prelude::*};
+use bevy::{asset::AssetPlugin, pbr::AmbientLight, prelude::*};
 use bevy_kira_audio::prelude::*;
 
 use bevy_rapier2d::geometry::Group;
@@ -100,6 +100,25 @@ fn setup_panic() {
     panic::set_hook(Box::new(console_error_panic_hook::hook)); // pushes rust errors to the browser console
 }
 
+fn our_default_plugins(
+    display_config: options::DisplayConfig,
+    opts: options::GameInitCLIOptions,
+) -> PluginGroupBuilder {
+    let res = DefaultPlugins
+        .set(WindowPlugin {
+            primary_window: Some(Window::from(display_config)),
+            ..default()
+        })
+        .set(ImagePlugin::default_nearest());
+
+    match opts.assets_dir {
+        Some(path_) => res.set(AssetPlugin {
+            asset_folder: path_.to_string_lossy().to_string(),
+            ..Default::default()
+        }),
+        None => res,
+    }
+}
 fn main() {
     #[cfg(target_arch = "wasm32")]
     setup_panic();
@@ -107,12 +126,11 @@ fn main() {
     let display_config = get_display_config();
 
     let mut app = build_app(
-        DefaultPlugins
-            .set(WindowPlugin {
-                primary_window: Some(Window::from(display_config)),
-                ..default()
-            })
-            .set(ImagePlugin::default_nearest()),
+        our_default_plugins(
+            display_config,
+            options::GameInitCLIOptions::from_environ_on_supported_platforms_with_default_fallback(
+            ),
+        ),
         ThetawaveGamePlugins,
     );
 

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -1,0 +1,9 @@
+#[test]
+#[cfg(all(not(target_arch = "wasm32"), feature = "cli"))]
+fn test_cli_help() {
+    // Run this as an integration test because we need the whole game binary to be built.
+    assert_cmd::Command::cargo_bin("thetawave")
+        .unwrap()
+        .args(&["--help"])
+        .unwrap();
+}


### PR DESCRIPTION
(and maybe a few more params?) so that we can set this during the steam launch. We need to set it explicitly because of how steam asks us to bundle depots/platform-specific assets.

We _could_ put this struct typedef in `thetawave_interface` but it is fine in `thetawave::options` for now. 

`thetawave --assets-dir some_directory/` and `thetawave --help` 

This _should_ be cross platform. 