### PR TITLE
Conditionally compile the wasm console error panic hook 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install bevy deps
         run: |
           set -euxo pipefail
-          sudo apt install -y lld g++ pkg-config libx11-dev libasound2-dev libudev-dev
+          sudo apt update && sudo apt upgrade && sudo apt install -y lld g++ pkg-config libx11-dev libasound2-dev libudev-dev
       - name: Cache deps
         uses: actions/cache@v3
         with:
@@ -85,7 +85,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: |
           set -euxo pipefail
-          sudo apt install -y lld g++ pkg-config libx11-dev libasound2-dev libudev-dev
+          sudo apt update && sudo apt upgrade && sudo apt install -y lld g++ pkg-config libx11-dev libasound2-dev libudev-dev
         shell: bash
       - name: Cache deps
         uses: actions/cache@v3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ bevy_kira_audio = { version = "0.16.0", features = ["mp3", "wav"] }
 # We value minimizing the binary sizes and keeping the CLI maximally simple over a more feature complete CLI library
 # like clap.
 argh = "0.1.12"
+console_error_panic_hook = "0.1.7"
 
 
 [dev-dependencies]
@@ -46,7 +47,6 @@ strum = { workspace = true }
 strum_macros = { workspace = true }
 ron = "0.8.0"
 rand = "0.8.5"
-console_error_panic_hook = "0.1.7"
 bevy_kira_audio = { workspace = true }
 winit = "0.28.4"
 image = "0.24.6"
@@ -61,6 +61,8 @@ thetawave_storage = { path = "crates/thetawave_storage", optional = true }
 thetawave_arcade = { path = "crates/thetawave_arcade", optional = true }
 argh = { workspace = true, optional = true}
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+console_error_panic_hook = { workspace = true }
 
 # optimize dev packages as we don't need them in debug version
 [profile.dev.package."*"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -94,12 +94,6 @@ fn get_display_config() -> options::DisplayConfig {
     }
 }
 
-#[allow(dead_code)]
-fn setup_panic() {
-    use std::panic;
-    panic::set_hook(Box::new(console_error_panic_hook::hook)); // pushes rust errors to the browser console
-}
-
 fn our_default_plugins(
     display_config: options::DisplayConfig,
     opts: options::GameInitCLIOptions,
@@ -120,8 +114,9 @@ fn our_default_plugins(
     }
 }
 fn main() {
+    // pushes rust errors to the browser console
     #[cfg(target_arch = "wasm32")]
-    setup_panic();
+    std::panic::set_hook(Box::new(console_error_panic_hook::hook));
 
     let display_config = get_display_config();
 


### PR DESCRIPTION
to slightly trim down the shipped native binaries.

not quite an atomic PR but atleast there are 2 atomic commits. turns out we need to `apt update` to fix CI. 


This console error panic hook also brings in things like `wasm_bindgen`. 

`cargo build --features storage --features cli`
shows 457 deps 

and `cargo tree --features storage --features cli | wc -l` shows 1188 on this branch vs 470 and 1207 on main, respectively. 