### PR TITLE
Assets/public asset server url

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,77 @@
+# Contributing to Thetawave
+
+## Building and Running Tests
+
+```bash
+cargo test --workspace --all-features
+```
+
+Running the game locally
+```
+cargo run --release --features storage
+```
+
+Building the game with arcade functionality.
+
+```
+cargo build --release features storage --features arcade
+```
+
+Build and run the game for wasm. 
+
+Run 
+```bash
+./build_wasm.sh
+```
+Then serve the `out/` directory with some HTTP server.
+
+For example
+
+```bash
+python3 -m http.server -d out/
+```
+
+## Assets
+
+We choose to store most images and audio (10Mb-1Gb) in [AWS S3](https://aws.amazon.com/s3/), rather than in git.
+
+
+To contribute to the assets, do the following.
+
+0. Create an AWS account.
+0. [Create an IAM User](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_users_create.html) on your AWS account. This
+   is distinct from your account's root user. Let's call this IAM user `mythetawavedev`. 
+0. Send a repo maintainer your IAM User ARN. It will look something like
+   `arn:aws:iam::121767489999:user/mythetawavedev`. The maintainer will allow you to use an AWS IAM Role that gives
+short term access to the assets 
+0. For web browser/console/interactive access [see the ThetawaveDeveloperRole IAM role login](
+   https://signin.aws.amazon.com/switchrole?roleName=ThetawaveDeveloperRole&account=6564541241021).  For example, in the
+[`assets-thetawave` bucket console](https://s3.console.aws.amazon.com/s3/buckets/assets-thetawave?) one can manually
+upload assets.
+0. To download all of the assets from a local development environment using the
+   [aws-cli](https://github.com/aws/aws-cli), I recommend creating an `~/.aws/credentials` file like the following.
+   ```ini
+   [thetawavedev]
+   aws_access_key_id = <MY_ACCESS_KEY>
+   aws_secret_access_key = <MY_SECRET_KEY>
+   region = us-east-2
+   ```
+
+   and an ~/.aws/config` file  like
+
+   ```ini
+   [profile thetawavedev-p]
+   role_arn = arn:aws:iam::656454124102:role/ThetawaveDeveloperRole
+   source_profile = thetawavedev
+   role_session_name = <A_NAME_FOR_YOUR_SESSION>
+   ```
+   Then run `./asset-manager.sh get-free` or `./asset-manger.sh get-premium` to invoke the AWS CLI. Or look at that
+script to figure out how to invoke the AWS CLI yourself. AWS has more docs about [configuring
+credentials](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html)
+0. If you are using another open source tool for interacting with S3, such as
+   [`rclone`](https://github.com/rclone/rclone), you may need to use `--s3-profile` or do something like the following.
+```bash
+export AWS_SESSION_TOKEN=$(aws sts assume-role --profile thetawavedev --output text \
+    --role-arn arn:aws:iam::656454124102:role/ThetawaveDeveloperRole \
+    --role-session-name vpsession --query="Credentials.SessionToken" )
+```

--- a/asset_manager.sh
+++ b/asset_manager.sh
@@ -1,12 +1,14 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -euxo pipefail
+
 if [ "$1" = "get-free" ]; then
-    aws s3 cp s3://thetawave-assets/free_assets/planets/ ./assets/models/planets/ --recursive --no-sign-request
-    aws s3 cp s3://thetawave-assets/free_assets/backgrounds/ ./assets/texture/backgrounds/ --recursive --no-sign-request
+    aws s3 cp --profile thetawavedev-p --recursive s3://assets-thetawave/free_assets/models/planets/ ./assets/models/planets/
+    aws s3 cp --profile thetawavedev-p --recursive s3://assets-thetawave/free_assets/texture/backgrounds/ ./assets/texture/backgrounds/
+    aws s3 cp --profile thetawavedev-p --recursive s3://assets-thetawave/free_assets/sounds ./assets/sounds/
 elif [ "$1" = "get-premium" ]; then
-    aws s3 cp s3://thetawave-assets/premium_assets/planets/ ./assets/models/planets/ --recursive
-    aws s3 cp s3://thetawave-assets/premium_assets/backgrounds/ ./assets/texture/backgrounds/ --recursive
+    aws s3 cp --profile thetawavedev-p --recursive s3://assets-thetawave/premium_assets/ ./assets/
 elif [ "$1" = "remove" ]; then
     rm -rf ./assets/models/planets
     rm -rf ./assets/texture/backgrounds
+    rm -rf ./assets/sounds/
 fi

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,11 @@
 [[redirects]]
 from = "/assets/backgrounds/*"
-to = "https://assets.thetawave.metalmancy.tech/free_assets/backgrounds/:splat"
+to = "https://assets.thetawave.metalmancy.tech/free_assets/texture/backgrounds/:splat"
 
 [[redirects]]
 from = "/assets/planets/*"
-to = "https://assets.thetawave.metalmancy.tech/free_assets/planets/:splat"
+to = "https://assets.thetawave.metalmancy.tech/free_assets/models/planets/:splat"
+
+[[redirects]]
+from = "/assets/sounds/*"
+to = "https://assets.thetawave.metalmancy.tech/free_assets/sounds/:splat"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,7 @@
 [[redirects]]
 from = "/assets/backgrounds/*"
-to = "https://thetawave-assets.s3.amazonaws.com/free_assets/backgrounds/:splat"
+to = "https://assets.thetawave.metalmancy.tech/free_assets/backgrounds/:splat"
 
 [[redirects]]
 from = "/assets/planets/*"
-to = "https://thetawave-assets.s3.amazonaws.com/free_assets/planets/:splat"
+to = "https://assets.thetawave.metalmancy.tech/free_assets/planets/:splat"


### PR DESCRIPTION
@cdsupina you asked me to make a new bucket since you didnt want to care about this trash, so I did. 

This one hooks up a part of it to cloudfront. and is otherwise fairly locked down. Having a public read s3 bucket is generally not great because we pay when people download from the bucket (so someone could just run ./asset-manager.sh 100k times and we need to pay), so we want to control how that happens and generally serve public-facing assets from a CDN, while locking down privileges to the s3 service. 

The key here is an IAM User role that can be assumed by @cdsupina , me and maybe @LordDeatHunter  