### PR TITLE
Reduce bevy install features to reduce build times and binary size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,6 @@ bevy_rapier2d = { version = "0.22.0", features = [
     "simd-stable",
     "debug-render-2d",
 ] }
-bevy_egui = "0.21.0"
 bevy_asset_loader = { version = "0.17.0", features = [
     "2d",
     "3d",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ members = [
 serde = "1.0.159"
 strum = "0.25.0"
 strum_macros = "0.25.1"
-bevy = { version = "0.11.2", features = ["serialize"] }
 thiserror = "1.0"
 derive_more = "0.99.17"
 bevy_ecs_macros = "0.11.2"
@@ -25,6 +24,36 @@ bevy_kira_audio = { version = "0.16.0", features = ["mp3", "wav"] }
 argh = "0.1.12"
 console_error_panic_hook = "0.1.7"
 
+[workspace.dependencies.bevy]
+version = "0.11.2"
+default-features = false
+features = [
+  # Non-default/'extra' features features
+  "serialize",
+  # Part of bevy's default features
+  "animation",
+  "bevy_asset",
+  "bevy_audio",
+  "bevy_gilrs",
+  "bevy_scene",
+  "bevy_winit",
+  "bevy_core_pipeline",
+  "bevy_pbr",
+  "bevy_gltf",
+  "bevy_render",
+  "bevy_sprite",
+  "bevy_text",
+  "bevy_ui",
+  "hdr",
+  "ktx2",
+  "tonemapping_luts",
+  "multi-threaded",
+  "png",
+  "x11",
+  "bevy_gizmos",
+  "webgl2",
+  "zstd",
+]
 
 [dev-dependencies]
 rstest = "0.18.2"


### PR DESCRIPTION
This cuts down ~18/450 deps from `cargo build --features storage`  It cuts the linux binary size by ~5% and the Wasm binary size ~10% (~24Mb->22Mb). 

https://github.com/bevyengine/bevy/blob/main/docs/cargo_features.md

The default features we no longer use are:
- vorbis
- default_font

Also no more bevy_egui


