### PR TITLE
Spawn menu explorer in wasm32 build to fix input issue

### DIFF
--- a/src/options/mod.rs
+++ b/src/options/mod.rs
@@ -50,8 +50,10 @@ impl Plugin for OptionsPlugin {
 
         app.insert_resource(InputsResource::from(get_input_bindings()));
 
+        app.add_systems(Startup, spawn_menu_explorer_system);
+
         #[cfg(not(target_arch = "wasm32"))]
-        app.add_systems(Startup, (set_window_icon, spawn_menu_explorer_system));
+        app.add_systems(Startup, set_window_icon);
 
         app.add_systems(Update, toggle_fullscreen_system);
 


### PR DESCRIPTION
The input issue was the the spawn_menu_explorer system wasn't being called in the wasm32 build.