### PR TITLE
Remove unused pub use import. 

### DIFF
--- a/src/spawnable/mod.rs
+++ b/src/spawnable/mod.rs
@@ -38,7 +38,7 @@ pub use self::behavior_sequence::{
     BehaviorSequenceResource, MobBehaviorUpdateEvent,
 };
 
-pub use self::effect::{EffectData, EffectsResource, SpawnEffectEvent};
+pub use self::effect::{EffectsResource, SpawnEffectEvent};
 
 pub use self::consumable::{
     consumable_execute_behavior_system, spawn_consumable_system, ConsumableComponent,


### PR DESCRIPTION
rustc seems to do a better job at detecting unused imports than on previous builds