### PR TITLE
Compute the fire rate using a method rather than updating the PlayerComponents each frame

### DIFF
--- a/crates/thetawave_interface/src/player.rs
+++ b/crates/thetawave_interface/src/player.rs
@@ -76,10 +76,12 @@ pub struct PlayerComponent {
     pub projectile_velocity: Vec2,
     /// Position of projectile spawn relative to player
     pub projectile_offset_position: Vec2,
-    /// Tracks time between firing blasts
+    /// Tracks time between firing blasts. Systems in the game must (re)set this as needed.
     pub fire_timer: Timer,
-    /// Time between firing projectiles
-    pub fire_period: f32,
+    /// The 'default' or initial time (in seconds) between shooting the main gun that all
+    /// characters have. 'recharge period/duration.' Use traits to compute/derive a fire rate
+    /// suitable for the game. This is generally immutable.
+    pub base_attack_cooldown_seconds: f32,
     /// Amount of damage dealt per attack
     pub attack_damage: usize,
     /// Amount of damage dealt on contact
@@ -117,7 +119,7 @@ impl From<&Character> for PlayerComponent {
             projectile_velocity: character.projectile_velocity,
             projectile_offset_position: character.projectile_offset_position,
             fire_timer: Timer::from_seconds(character.fire_period, TimerMode::Once),
-            fire_period: character.fire_period,
+            base_attack_cooldown_seconds: character.fire_period,
             attack_damage: character.attack_damage,
             collision_damage: character.collision_damage,
             attraction_distance: character.attraction_distance,

--- a/src/player/mod.rs
+++ b/src/player/mod.rs
@@ -20,7 +20,7 @@ pub use self::{
     spawn::spawn_players_system,
     systems::{
         player_ability_system, player_death_system, player_fire_weapon_system,
-        player_movement_system, player_scale_fire_rate_system, players_reset_system,
+        player_movement_system, players_reset_system,
     },
 };
 
@@ -48,7 +48,6 @@ impl Plugin for PlayerPlugin {
             (
                 player_fire_weapon_system,
                 player_death_system,
-                player_scale_fire_rate_system,
                 player_movement_system.in_set(GameUpdateSet::Movement),
                 player_ability_system.in_set(GameUpdateSet::Abilities),
             )

--- a/src/player/systems/mod.rs
+++ b/src/player/systems/mod.rs
@@ -13,7 +13,7 @@ use thetawave_interface::run::{RunDefeatType, RunEndEvent, RunOutcomeType};
 use thetawave_interface::spawnable::EffectType;
 
 pub use self::ability::*;
-pub use self::attacks::{player_fire_weapon_system, player_scale_fire_rate_system};
+pub use self::attacks::player_fire_weapon_system;
 pub use self::movement::player_movement_system;
 
 use super::PlayersResource;


### PR DESCRIPTION
This reduces the number of times the fire rate is recalculated and avoids taking mutable/exclusive access to the players every frame.

This `PlayerComponent.fire_period` or what I renamed to `base_attack_cooldown_seconds` isnt really being used for anything. Should we delete it? Do you want this to not depend at all on the character type (captain vs juggernaut)?

Right now, the fire rate is entirely determined by 

```rust
1.0 / (1.5 * ((0.8 * player.money as f32) + 4.0).ln())
```

Technically we could also memoize this, but it shouldnt need to be recomputed every frame. I kinda prefer this to incrementally updating a struct field because here we know exactly why the value is what it is. 