### PR TITLE
Setup Rapier Physics to Use Fixed Update

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -189,9 +189,10 @@ impl PluginGroup for ThetawaveGamePlugins {
             .add(states::StatesPlugin)
             .add(game::counters::plugin::CountingMetricsPlugin)
             .add(misc::HealthPlugin)
-            .add(RapierPhysicsPlugin::<NoUserData>::pixels_per_meter(
-                PHYSICS_SCALE,
-            ))
+            .add(
+                RapierPhysicsPlugin::<NoUserData>::pixels_per_meter(PHYSICS_SCALE)
+                    .in_fixed_schedule(),
+            )
             .add(ui::UiPlugin)
             .add(options::OptionsPlugin::default())
             .add(audio::ThetawaveAudioPlugin);


### PR DESCRIPTION
Rapier physics by default does not run on a fixed update schedule meaning that the physics simulation goes at the speed of the game. Fixed update will make sure that when the game slows down the physics simulation keeps up.

@LordDeatHunter This solves the issue with the projectile range you were describing.