### PR TITLE
Nit/rustc warnings20240222

### DIFF
--- a/crates/thetawave_interface/src/game/historical_metrics.rs
+++ b/crates/thetawave_interface/src/game/historical_metrics.rs
@@ -2,7 +2,6 @@
 //! corresponding systems are not 'online' to mutate the resources.
 use crate::spawnable::EnemyMobType;
 use bevy_ecs_macros::Resource;
-use derive_more;
 use std::collections::HashMap;
 
 /// The 'model' of the UserStat Sqlite table. Persisted user stats about past games.

--- a/crates/thetawave_storage/src/core.rs
+++ b/crates/thetawave_storage/src/core.rs
@@ -1,7 +1,6 @@
 use bevy::log::info;
 use directories::ProjectDirs;
-use rusqlite::Connection;
-use rusqlite::{self, OptionalExtension};
+use rusqlite::{self, Connection};
 use std::env::var_os;
 use std::ffi::OsStr;
 use std::path::PathBuf;

--- a/crates/thetawave_storage/src/core.rs
+++ b/crates/thetawave_storage/src/core.rs
@@ -1,6 +1,6 @@
 use bevy::log::info;
 use directories::ProjectDirs;
-use rusqlite::{self, Connection};
+use rusqlite::Connection;
 use std::env::var_os;
 use std::ffi::OsStr;
 use std::path::PathBuf;

--- a/crates/thetawave_storage/src/user_stats.rs
+++ b/crates/thetawave_storage/src/user_stats.rs
@@ -1,5 +1,5 @@
 use crate::core::{get_db, OurDBError, ENEMY_KILL_HISTORY_TABLE_NAME, USERSTAT};
-use bevy::prelude::{error, info};
+use bevy::utils::tracing::{error, info};
 use rusqlite::{params, Result};
 use thetawave_interface::spawnable::EnemyMobType;
 

--- a/src/arena/barrier.rs
+++ b/src/arena/barrier.rs
@@ -1,6 +1,8 @@
 use crate::collision::{HORIZONTAL_BARRIER_COLLIDER_GROUP, SPAWNABLE_COLLIDER_GROUP};
 use crate::{game::GameParametersResource, spawnable::SpawnEffectEvent};
-use bevy::prelude::*;
+use bevy::prelude::{
+    Commands, Component, EventWriter, Name, Quat, Res, Transform, TransformBundle, Vec2, Vec3,
+};
 use bevy_rapier2d::prelude::*;
 use std::f32::consts::FRAC_PI_2;
 use thetawave_interface::{spawnable::EffectType, states::GameCleanup};
@@ -32,7 +34,7 @@ pub fn spawn_barriers_system(
             scale: Vec3::new(10.0, game_parameters.sprite_scale, 1.0),
             ..Default::default()
         },
-        ..default()
+        ..Default::default()
     });
     spawn_effect.send(SpawnEffectEvent {
         effect_type: EffectType::BarrierGlow,
@@ -41,7 +43,7 @@ pub fn spawn_barriers_system(
             scale: Vec3::new(10.0, game_parameters.sprite_scale, 1.0),
             ..Default::default()
         },
-        ..default()
+        ..Default::default()
     });
     spawn_effect.send(SpawnEffectEvent {
         effect_type: EffectType::BarrierGlow,
@@ -50,7 +52,7 @@ pub fn spawn_barriers_system(
             scale: Vec3::new(7.3, game_parameters.sprite_scale, 1.0),
             rotation: Quat::from_rotation_z(FRAC_PI_2),
         },
-        ..default()
+        ..Default::default()
     });
     spawn_effect.send(SpawnEffectEvent {
         effect_type: EffectType::BarrierGlow,
@@ -59,7 +61,7 @@ pub fn spawn_barriers_system(
             scale: Vec3::new(7.3, game_parameters.sprite_scale, 1.0),
             rotation: Quat::from_rotation_z(FRAC_PI_2),
         },
-        ..default()
+        ..Default::default()
     });
 }
 

--- a/src/assets/consumable.rs
+++ b/src/assets/consumable.rs
@@ -1,5 +1,5 @@
-use bevy::prelude::*;
-use bevy_asset_loader::prelude::*;
+use bevy::prelude::{Color, Handle, Resource, TextureAtlas};
+use bevy_asset_loader::prelude::AssetCollection;
 
 use thetawave_interface::spawnable::ConsumableType;
 

--- a/src/assets/item.rs
+++ b/src/assets/item.rs
@@ -1,5 +1,5 @@
-use bevy::prelude::*;
-use bevy_asset_loader::prelude::*;
+use bevy::prelude::{Handle, Resource, TextureAtlas};
+use bevy_asset_loader::prelude::AssetCollection;
 
 use thetawave_interface::spawnable::ItemType;
 

--- a/src/assets/mob.rs
+++ b/src/assets/mob.rs
@@ -1,5 +1,5 @@
-use bevy::prelude::*;
-use bevy_asset_loader::prelude::*;
+use bevy::prelude::{Color, Handle, Resource, TextureAtlas};
+use bevy_asset_loader::prelude::AssetCollection;
 use thetawave_interface::spawnable::{
     AllyMobType, EnemyMobSegmentType, EnemyMobType, MobSegmentType, MobType, NeutralMobSegmentType,
     NeutralMobType,

--- a/src/assets/player.rs
+++ b/src/assets/player.rs
@@ -1,5 +1,5 @@
-use bevy::prelude::*;
-use bevy_asset_loader::prelude::*;
+use bevy::prelude::{Handle, Image, Resource};
+use bevy_asset_loader::prelude::AssetCollection;
 use thetawave_interface::character::CharacterType;
 
 #[derive(AssetCollection, Resource)]

--- a/src/assets/projectile.rs
+++ b/src/assets/projectile.rs
@@ -1,5 +1,5 @@
-use bevy::prelude::*;
-use bevy_asset_loader::prelude::*;
+use bevy::prelude::{Color, Handle, Resource, TextureAtlas};
+use bevy_asset_loader::prelude::AssetCollection;
 use thetawave_interface::spawnable::{Faction, ProjectileType};
 
 #[derive(AssetCollection, Resource)]

--- a/src/audio/mod.rs
+++ b/src/audio/mod.rs
@@ -1,5 +1,7 @@
-use bevy::prelude::*;
-use bevy_kira_audio::prelude::*;
+use bevy::prelude::{
+    in_state, not, App, EventReader, IntoSystemConfigs, Plugin, Res, Resource, Startup, Update,
+};
+use bevy_kira_audio::prelude::{AudioApp, AudioChannel, AudioControl, AudioEasing, AudioTween};
 use thetawave_interface::{
     audio::{ChangeBackgroundMusicEvent, PlaySoundEffectEvent},
     states::AppStates,

--- a/src/background/mod.rs
+++ b/src/background/mod.rs
@@ -2,7 +2,6 @@
 
 use std::fs;
 
-use bevy::prelude::Commands;
 use bevy::prelude::*;
 use rand::{seq::IteratorRandom, Rng};
 use ron::de::from_bytes;

--- a/src/collision/intersection.rs
+++ b/src/collision/intersection.rs
@@ -1,8 +1,8 @@
 use crate::spawnable::{
     ConsumableComponent, MobComponent, MobSegmentComponent, ProjectileComponent,
 };
-use bevy::prelude::*;
-use bevy_rapier2d::{prelude::*, rapier::prelude::CollisionEventFlags};
+use bevy::prelude::{debug, Entity, EventReader, EventWriter, Query, With};
+use bevy_rapier2d::{prelude::CollisionEvent, rapier::prelude::CollisionEventFlags};
 use thetawave_interface::{
     player::PlayerComponent,
     spawnable::{Faction, ItemComponent, MobSegmentType, MobType, ProjectileType},

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,13 @@
 use bevy::app::PluginGroupBuilder;
-use bevy::{asset::AssetPlugin, pbr::AmbientLight, prelude::*};
-use bevy_kira_audio::prelude::*;
+use bevy::prelude::{
+    AmbientLight, App, AssetPlugin, ClearColor, Color, DefaultPlugins, ImagePlugin,
+    IntoSystemConfigs, OnEnter, PluginGroup, ResMut, SystemSet, Vec2, Window, WindowPlugin,
+};
+use bevy_kira_audio::prelude::AudioPlugin;
 
-use bevy_rapier2d::prelude::*;
+use bevy_rapier2d::prelude::{
+    NoUserData, RapierConfiguration, RapierDebugRenderPlugin, RapierPhysicsPlugin, TimestepMode,
+};
 use options::{generate_config_files, GameInitCLIOptions};
 use thetawave_interface::states::{AppStates, GameStates};
 
@@ -83,7 +88,7 @@ fn our_default_plugins(
     let res = DefaultPlugins
         .set(WindowPlugin {
             primary_window: Some(Window::from(display_config)),
-            ..default()
+            ..Default::default()
         })
         .set(ImagePlugin::default_nearest());
 

--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -1,4 +1,11 @@
-use bevy::{math::Vec3Swizzles, prelude::*, window::PrimaryWindow};
+use bevy::{
+    prelude::{
+        in_state, App, Entity, IntoSystemConfigs, Plugin, Query, Res, Transform, Update, Vec2,
+        Vec3Swizzles, Window, With,
+    },
+    utils::tracing::debug,
+    window::PrimaryWindow,
+};
 use thetawave_interface::health::HealthComponent;
 
 use crate::{game::GameParametersResource, spawnable::MobComponent};

--- a/src/spawnable/behavior.rs
+++ b/src/spawnable/behavior.rs
@@ -2,8 +2,8 @@ use crate::{
     collision::SortedCollisionEvent, game::GameParametersResource, spawnable::SpawnableComponent,
     tools::signed_modulo,
 };
-use bevy::{math::Vec3Swizzles, prelude::*};
-use bevy_rapier2d::prelude::*;
+use bevy::prelude::{Entity, EventReader, Query, Res, Transform, Vec2, Vec3Swizzles, With};
+use bevy_rapier2d::prelude::Velocity;
 use serde::Deserialize;
 use thetawave_interface::spawnable::AttractToClosestPlayerComponent;
 use thetawave_interface::{

--- a/src/spawnable/consumable/mod.rs
+++ b/src/spawnable/consumable/mod.rs
@@ -1,5 +1,8 @@
-use bevy::prelude::*;
-use bevy_rapier2d::prelude::*;
+use bevy::prelude::{
+    Commands, Component, Event, EventReader, Name, Res, Resource, SpriteSheetBundle,
+    TextureAtlasSprite, Timer, TimerMode, Transform, Vec2, Vec3,
+};
+use bevy_rapier2d::prelude::{ActiveEvents, Collider, LockedAxes, RigidBody, Sensor, Velocity};
 use serde::Deserialize;
 use std::collections::HashMap;
 use thetawave_interface::{

--- a/src/spawnable/effect/spawn.rs
+++ b/src/spawnable/effect/spawn.rs
@@ -2,8 +2,12 @@ use crate::animation::AnimationComponent;
 use crate::assets::EffectAssets;
 use crate::spawnable::effect::{EffectComponent, TextEffectData, TextEffectsResource};
 use crate::spawnable::{EffectsResource, InitialMotion, SpawnEffectEvent, SpawnableComponent};
-use bevy::prelude::*;
-use bevy_rapier2d::prelude::*;
+use bevy::prelude::{
+    in_state, App, AssetServer, Commands, EventReader, IntoSystemConfigs, Name, Plugin, Res,
+    SpriteSheetBundle, Text, Text2dBundle, TextStyle, TextureAtlasSprite, Timer, TimerMode,
+    Transform, Update, Vec3,
+};
+use bevy_rapier2d::prelude::{LockedAxes, RigidBody, Velocity};
 use rand::Rng;
 use thetawave_interface::game::options::GameOptions;
 use thetawave_interface::spawnable::{EffectType, SpawnableType, TextEffectType};
@@ -112,7 +116,10 @@ fn spawn_text_effect(
 
     // spawn text effect entity
     commands
-        .spawn(Text2dBundle { text, ..default() })
+        .spawn(Text2dBundle {
+            text,
+            ..Default::default()
+        })
         .insert(
             transform
                 .with_translation(
@@ -131,7 +138,7 @@ fn spawn_text_effect(
         )
         .insert(SpawnableComponent {
             spawnable_type: SpawnableType::Effect(EffectType::Text(text_effect_type.clone())),
-            ..default()
+            ..Default::default()
         })
         .insert(EffectComponent::from(effect_data))
         .insert(GameCleanup);
@@ -175,7 +182,7 @@ fn spawn_effect(
         .insert(EffectComponent::from(effect_data))
         .insert(SpawnableComponent {
             spawnable_type: SpawnableType::Effect(effect_data.effect_type.clone()),
-            ..default()
+            ..Default::default()
         })
         .insert(LockedAxes::default())
         .insert(RigidBody::KinematicVelocityBased)

--- a/src/spawnable/item/spawn.rs
+++ b/src/spawnable/item/spawn.rs
@@ -1,5 +1,8 @@
-use bevy::prelude::*;
-use bevy_rapier2d::prelude::*;
+use bevy::prelude::{
+    in_state, App, Commands, EventReader, IntoSystemConfigs, Name, Plugin, Res, SpriteSheetBundle,
+    Timer, TimerMode, Transform, Update, Vec2, Vec3,
+};
+use bevy_rapier2d::prelude::{ActiveEvents, Collider, LockedAxes, RigidBody, Sensor, Velocity};
 use thetawave_interface::spawnable::{ItemComponent, SpawnItemEvent};
 use thetawave_interface::{
     spawnable::ItemType,
@@ -78,7 +81,7 @@ pub fn spawn_item(
     // Sprite components
     item.insert(SpriteSheetBundle {
         texture_atlas: item_assets.get_asset(item_type),
-        ..default()
+        ..Default::default()
     })
     .insert(AnimationComponent {
         timer: Timer::from_seconds(item_data.animation.frame_duration, TimerMode::Repeating),
@@ -97,7 +100,7 @@ pub fn spawn_item(
             game_parameters.sprite_scale,
             1.0,
         ),
-        ..default()
+        ..Default::default()
     });
 
     // Collider components

--- a/src/spawnable/mob/behavior.rs
+++ b/src/spawnable/mob/behavior.rs
@@ -1,4 +1,3 @@
-use bevy::math::Vec3Swizzles;
 use bevy::prelude::*;
 use serde::Deserialize;
 use thetawave_interface::{

--- a/src/spawnable/mob/mob_segment/behavior.rs
+++ b/src/spawnable/mob/mob_segment/behavior.rs
@@ -1,6 +1,5 @@
-use bevy::math::Vec3Swizzles;
 use bevy::prelude::*;
-use bevy_rapier2d::{prelude::*, rapier::prelude::JointAxis};
+use bevy_rapier2d::prelude::{ImpulseJoint, JointAxis};
 use rand::{thread_rng, Rng};
 use serde::Deserialize;
 use thetawave_interface::{

--- a/src/spawnable/mob/mod.rs
+++ b/src/spawnable/mob/mod.rs
@@ -1,11 +1,10 @@
 use bevy::prelude::*;
-use bevy_rapier2d::geometry::Group;
-use bevy_rapier2d::prelude::*;
-use serde::Deserialize;
-use std::{
-    collections::{hash_map::Entry, HashMap},
-    string::ToString,
+use bevy_rapier2d::prelude::{
+    ActiveEvents, CoefficientCombineRule, Collider, CollisionGroups, Friction, Group, LockedAxes,
+    Restitution, RevoluteJointBuilder, RigidBody, Velocity,
 };
+use serde::Deserialize;
+use std::collections::{hash_map::Entry, HashMap};
 
 use crate::{
     animation::{AnimationComponent, AnimationData},
@@ -17,7 +16,7 @@ use crate::{
 
 mod behavior;
 mod mob_segment;
-pub use self::{behavior::*, mob_segment::*};
+pub(crate) use self::{behavior::*, mob_segment::*};
 
 use super::{behavior_sequence::MobBehaviorSequenceType, InitialMotion};
 use crate::collision::{
@@ -117,7 +116,6 @@ impl From<MobSpawnerData> for MobSpawner {
 }
 
 #[derive(Deserialize, Clone)]
-
 pub struct ProjectileSpawner {
     pub projectile_type: ProjectileType,
     pub timer: Timer,

--- a/src/spawnable/projectile/mod.rs
+++ b/src/spawnable/projectile/mod.rs
@@ -1,7 +1,7 @@
 use bevy::prelude::*;
 use bevy_rapier2d::prelude::*;
 use serde::Deserialize;
-use std::{collections::HashMap, string::ToString};
+use std::collections::HashMap;
 use thetawave_interface::{
     audio::PlaySoundEffectEvent,
     game::options::GameOptions,

--- a/src/spawnable/projectile/mod.rs
+++ b/src/spawnable/projectile/mod.rs
@@ -1,5 +1,10 @@
-use bevy::prelude::*;
-use bevy_rapier2d::prelude::*;
+use bevy::prelude::{
+    Commands, Component, Entity, Event, EventReader, EventWriter, Name, Quat, Res, Resource,
+    SpriteSheetBundle, TextureAtlasSprite, Timer, TimerMode, Transform, Vec2, Vec3Swizzles,
+};
+use bevy_rapier2d::prelude::{
+    ActiveEvents, Collider, CollisionGroups, Group, LockedAxes, RigidBody, Sensor, Velocity,
+};
 use serde::Deserialize;
 use std::collections::HashMap;
 use thetawave_interface::{

--- a/src/states/mod.rs
+++ b/src/states/mod.rs
@@ -1,4 +1,7 @@
-use bevy::prelude::*;
+use bevy::prelude::{
+    in_state, App, Commands, Component, DespawnRecursiveExt, Entity, IntoSystemConfigs,
+    IntoSystemSetConfigs, NextState, OnEnter, OnExit, Plugin, Query, ResMut, Update, With,
+};
 use bevy_asset_loader::prelude::*;
 use leafwing_input_manager::prelude::ActionState;
 use thetawave_interface::input::MenuAction;

--- a/src/states/pause_menu.rs
+++ b/src/states/pause_menu.rs
@@ -1,6 +1,6 @@
-use bevy::prelude::*;
-use bevy_kira_audio::prelude::*;
-use bevy_rapier2d::prelude::*;
+use bevy::prelude::{AssetServer, NextState, Query, Res, ResMut, With};
+use bevy_kira_audio::prelude::{AudioChannel, AudioControl};
+use bevy_rapier2d::prelude::RapierConfiguration;
 use leafwing_input_manager::prelude::ActionState;
 use thetawave_interface::input::{MenuAction, MenuExplorer};
 use thetawave_interface::states::GameStates;


### PR DESCRIPTION
We run the nightly toolchain (including clippy) and require compilation without warnings (atleast for 1 kind of build). So once in a while, the build will break because rustc warns about more things.  

This pr makes names more explicit. 

I need to merge this so #158 can build+merge