### PR TITLE
Fix missile behavior by adding can_rotate variable to mobs

### DIFF
--- a/assets/data/mobs.ron
+++ b/assets/data/mobs.ron
@@ -635,6 +635,7 @@
 		mob_behaviors: [ExplodeOnImpact, DealDamageToPlayerOnImpact, ReceiveDamageOnImpact, DieAtZeroHealth],
 		acceleration: (12.0, 2.0),
 		deceleration: (5.0, 5.0),
+		can_rotate: true,
 		speed: (150.0, 150.0),
 		angular_acceleration: 0.5,
 		angular_speed: 1.8,

--- a/src/spawnable/behavior.rs
+++ b/src/spawnable/behavior.rs
@@ -52,16 +52,13 @@ pub fn spawnable_execute_behavior_system(
                 SpawnableBehavior::MoveLeft => {
                     move_left(&spawnable_component, &mut rb_vel);
                 }
-                SpawnableBehavior::RotateToTarget(target_position) => {
-                    if let Some(target_position) = target_position {
-                        rotate_to_target(
-                            spawnable_transform,
-                            target_position,
-                            &spawnable_component,
-                            &mut rb_vel,
-                        );
-                    } else {
-                    }
+                SpawnableBehavior::RotateToTarget(Some(target_position)) => {
+                    rotate_to_target(
+                        spawnable_transform,
+                        target_position,
+                        &spawnable_component,
+                        &mut rb_vel,
+                    );
                 }
                 SpawnableBehavior::MoveForward => {
                     move_forward(spawnable_transform, &spawnable_component, &mut rb_vel);

--- a/src/spawnable/behavior.rs
+++ b/src/spawnable/behavior.rs
@@ -2,6 +2,7 @@ use crate::{
     collision::SortedCollisionEvent, game::GameParametersResource, spawnable::SpawnableComponent,
     tools::signed_modulo,
 };
+use bevy::log::info;
 use bevy::prelude::{Entity, EventReader, Query, Res, Transform, Vec2, Vec3Swizzles, With};
 use bevy_rapier2d::prelude::Velocity;
 use serde::Deserialize;
@@ -60,6 +61,7 @@ pub fn spawnable_execute_behavior_system(
                             &spawnable_component,
                             &mut rb_vel,
                         );
+                    } else {
                     }
                 }
                 SpawnableBehavior::MoveForward => {

--- a/src/spawnable/behavior.rs
+++ b/src/spawnable/behavior.rs
@@ -2,7 +2,6 @@ use crate::{
     collision::SortedCollisionEvent, game::GameParametersResource, spawnable::SpawnableComponent,
     tools::signed_modulo,
 };
-use bevy::log::info;
 use bevy::prelude::{Entity, EventReader, Query, Res, Transform, Vec2, Vec3Swizzles, With};
 use bevy_rapier2d::prelude::Velocity;
 use serde::Deserialize;

--- a/src/spawnable/mob/mod.rs
+++ b/src/spawnable/mob/mod.rs
@@ -183,6 +183,9 @@ pub struct MobData {
     pub mob_segment_behaviors: Option<
         HashMap<MobSegmentControlBehavior, HashMap<MobSegmentType, Vec<MobSegmentBehavior>>>,
     >,
+    /// Whether the mob can rotate on its z axis
+    #[serde(default)]
+    pub can_rotate: bool,
     /// Acceleration stat
     #[serde(default)]
     pub acceleration: Vec2,
@@ -369,7 +372,6 @@ pub fn spawn_mob(
         direction: mob_data.animation.direction.clone(),
     })
     .insert(RigidBody::Dynamic)
-    .insert(LockedAxes::ROTATION_LOCKED)
     .insert(Velocity::from(mob_data.initial_motion.clone()))
     .insert(Collider::compound(
         mob_data
@@ -396,6 +398,10 @@ pub fn spawn_mob(
 
     if boss {
         mob.insert(BossComponent);
+    }
+
+    if !mob_data.can_rotate {
+        mob.insert(LockedAxes::ROTATION_LOCKED);
     }
 
     if let Some(weapon_component) = mob_data.get_weapon_component() {


### PR DESCRIPTION
Rapier updated what LockedAxes::ROTATION_LOCKED does. It no longer allows us to manually rotate mobs through modifying the Velocity of a Rigidbody. With this change we now conditionally added LockedAxes using a can_rotate variable in MobData.