### PR TITLE
Fix a bug when we compiled with the arcade feature flag, but without the cli feature flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,9 @@ jobs:
       - name: Check that the game compiles and is minimally sensible rust (no warnings)
         run: cargo rustc --all-features -- -D warnings
 
+      - name: Check that the game compiles and is minimally sensible rust (no warnings) with just the arcade feature
+        run: cargo rustc --features arcade -- -D warnings
+
   test:
     name: ${{ matrix.name }}
     needs: [style]

--- a/src/options/mod.rs
+++ b/src/options/mod.rs
@@ -45,7 +45,7 @@ pub struct GameInitCLIOptions {
     /// 'EXECUTABLE_DIR/assets/' or 'CARGO_MANIFEST_DIR/assets'.
     pub assets_dir: Option<PathBuf>,
     #[cfg_attr(
-        all(not(target_arch = "wasm32"), feature = "arcade"),
+        all(not(target_arch = "wasm32"), feature = "cli", feature = "arcade"),
         argh(switch, short = 'a')
     )]
     /// whether to use instructions, serial port IO, etc. specific to deploying on an arcade


### PR DESCRIPTION
The fix ts to default to the same behavior we use in the browser, which is arcade=false and only add the argh cli arg when both the arcade & cli flags are enabled

Closes #174 