### PR TITLE
Fix Bug with Border Gradient Effect not Despawning

### DIFF
--- a/src/ui/game/border_gradient.rs
+++ b/src/ui/game/border_gradient.rs
@@ -16,7 +16,7 @@ use bevy::{
     },
     utils::default,
 };
-use thetawave_interface::objective::{DefenseInteraction, MobReachedBottomGateEvent};
+use thetawave_interface::{objective::{DefenseInteraction, MobReachedBottomGateEvent}, states::GameCleanup};
 
 use crate::assets::UiAssets;
 
@@ -50,7 +50,7 @@ impl BorderGradientCommandsExt for Commands<'_, '_> {
                 ..default()
             },
             ..default()
-        })
+        }).insert(GameCleanup)
         .with_children(|parent| {
             parent
                 .spawn(ImageBundle {

--- a/src/ui/game/border_gradient.rs
+++ b/src/ui/game/border_gradient.rs
@@ -16,7 +16,10 @@ use bevy::{
     },
     utils::default,
 };
-use thetawave_interface::{objective::{DefenseInteraction, MobReachedBottomGateEvent}, states::GameCleanup};
+use thetawave_interface::{
+    objective::{DefenseInteraction, MobReachedBottomGateEvent},
+    states::GameCleanup,
+};
 
 use crate::assets::UiAssets;
 
@@ -50,7 +53,8 @@ impl BorderGradientCommandsExt for Commands<'_, '_> {
                 ..default()
             },
             ..default()
-        }).insert(GameCleanup)
+        })
+        .insert(GameCleanup)
         .with_children(|parent| {
             parent
                 .spawn(ImageBundle {


### PR DESCRIPTION
GameCleanup component needed to be added to BorderGradient entity to flag it to be despawned on exit from game state. Fixes #181 