### PR TITLE
Remove Buttons from Main Menu with Arcade Feature or WASM32 Target

### DIFF
--- a/src/ui/main_menu/button.rs
+++ b/src/ui/main_menu/button.rs
@@ -92,7 +92,13 @@ pub(super) trait UiChildBuilderExt {
 
 impl UiChildBuilderExt for ChildBuilder<'_> {
     fn spawn_main_menu_buttons(&mut self, ui_assets: &UiAssets, font: Handle<Font>) -> &mut Self {
-        for action in MAIN_MENU_BUTTON_ORDER.iter() {
+        let buttons = if cfg!(feature = "arcade") {
+            vec![MainMenuButtonActionComponent::EnterInstructions]
+        } else {
+            Vec::from(MAIN_MENU_BUTTON_ORDER)
+        };
+
+        for action in buttons.iter() {
             self.spawn_main_menu_button(
                 ui_assets,
                 action.in_game_text().into(),

--- a/src/ui/main_menu/button.rs
+++ b/src/ui/main_menu/button.rs
@@ -92,13 +92,7 @@ pub(super) trait UiChildBuilderExt {
 
 impl UiChildBuilderExt for ChildBuilder<'_> {
     fn spawn_main_menu_buttons(&mut self, ui_assets: &UiAssets, font: Handle<Font>) -> &mut Self {
-        let buttons = if cfg!(feature = "arcade") {
-            vec![MainMenuButtonActionComponent::EnterInstructions]
-        } else {
-            Vec::from(MAIN_MENU_BUTTON_ORDER)
-        };
-
-        for action in buttons.iter() {
+        for action in MAIN_MENU_BUTTON_ORDER.iter() {
             self.spawn_main_menu_button(
                 ui_assets,
                 action.in_game_text().into(),

--- a/src/ui/main_menu/button.rs
+++ b/src/ui/main_menu/button.rs
@@ -67,12 +67,17 @@ impl MainMenuButtonActionComponent {
     }
 }
 /// This is the order (vertical, going down) of the buttons shown on the main menu UI.
+#[cfg(not(any(feature = "arcade", target_arch = "wasm32")))]
 const MAIN_MENU_BUTTON_ORDER: [MainMenuButtonActionComponent; 4] = [
     MainMenuButtonActionComponent::EnterInstructions,
     MainMenuButtonActionComponent::EnterOptions,
     MainMenuButtonActionComponent::EnterCompendium,
     MainMenuButtonActionComponent::QuitGame,
 ];
+
+#[cfg(any(feature = "arcade", target_arch = "wasm32"))]
+const MAIN_MENU_BUTTON_ORDER: [MainMenuButtonActionComponent; 1] =
+    [MainMenuButtonActionComponent::EnterInstructions];
 
 pub(super) type MainMenuButtonActionEvent = MainMenuButtonActionComponent;
 


### PR DESCRIPTION
We don't want users to be able to quit the game from the main menu when it is running on an arcade machine. Removed all other buttons besides the Play Game button for the arcade build. Fixes #180 